### PR TITLE
[codex] fix(ci): trigger push workflows after release auto-merge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -17,9 +17,19 @@ jobs:
       github.actor == 'github-actions[bot]' ||
       contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     steps:
-      - name: Auto-approve PR
+      - name: Auto-approve dependabot PRs
+        if: github.actor == 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review "${{ github.event.pull_request.number }}" --approve --repo "${{ github.repository }}" || true
+
+      - name: Auto-approve release-please PRs
+        if: >-
+          github.actor == 'github-actions[bot]' ||
+          contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+        env:
+          # Use the PAT-backed token here so the eventual merge commit triggers downstream push workflows.
+          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         run: gh pr review "${{ github.event.pull_request.number }}" --approve --repo "${{ github.repository }}" || true
 
       - name: Merge dependabot PRs (skip actions)
@@ -39,7 +49,8 @@ jobs:
           github.actor == 'github-actions[bot]' ||
           contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the PAT-backed token here so the merge commit triggers release/CI push workflows on main.
+          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: >-
           gh pr merge "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## What changed
- split automerge approval into separate dependabot and release-please paths
- keep dependabot merges on `GITHUB_TOKEN` with `[skip actions]`
- switch release-please approval and merge steps to `CI_GITHUB_TOKEN`

## Why
Release PR `#115` merged `main`, but the merge commit did not trigger the normal `push` workflows on `main`. That prevented the follow-on `Release` workflow from creating and publishing `edt-v6.2.0` automatically.

Using the PAT-backed `CI_GITHUB_TOKEN` for release-please merges preserves the intended behavior: release PR merges still auto-merge, but the resulting `main` push can trigger downstream `CI`, `CD`, and `Release` workflows.

## Recovery already performed
- manually dispatched the `Release` workflow on `main`
- confirmed `edt-v6.2.0` published successfully

## Validation
- verified the workflow edit is the only diff
- verified the workflow file contains the PAT-backed release-please approval/merge steps
- confirmed the manual release run published `edt-v6.2.0`
