### PR TITLE
fix(connectors): remediate dependency alerts and align docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
         {
           label: 'Vendor Connectors',
           items: [
+            { label: 'Overview', slug: 'packages/vendor-connectors' },
             { label: 'API Reference', link: '/api/apidocs/vendor_connectors/vendor_connectors/', attrs: { class: 'api-link' } },
           ],
         },

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -39,6 +39,8 @@ Extended Data provides four main packages that work together or independently:
     # Or specific extras
     pip install vendor-connectors[aws]      # AWS boto3
     pip install vendor-connectors[meshy]    # Meshy AI 3D
+    pip install vendor-connectors[langchain] # LangChain / LangGraph tools
+    pip install vendor-connectors[crewai]    # CrewAI tools
     pip install vendor-connectors[mcp]      # MCP server support
     pip install vendor-connectors[webhooks] # Webhook handling
     ```
@@ -316,6 +318,6 @@ All packages inherit from `DirectedInputsClass`, so they automatically load cred
   <Card title="Vendor Connectors" icon="rocket">
     Connect to cloud providers and AI services.
     
-    [Read the docs →](/api/vendor-connectors/)
+    [Read the docs →](/packages/vendor-connectors/)
   </Card>
 </CardGrid>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -208,6 +208,6 @@ Or install individually — each package works on its own.
   <LinkCard
     title="Vendor Connectors"
     description="AWS, GCP, GitHub, Slack, AI APIs — with LangChain and MCP"
-    href="/api/vendor-connectors/"
+    href="/packages/vendor-connectors/"
   />
 </CardGrid>

--- a/docs/src/content/docs/packages/index.mdx
+++ b/docs/src/content/docs/packages/index.mdx
@@ -28,7 +28,7 @@ The Extended Data ecosystem provides four production-ready Python packages that 
   <LinkCard
     title="Vendor Connectors"
     description="Universal connectors for AWS, GCP, GitHub, Slack, AI APIs"
-    href="/api/vendor-connectors/"
+    href="/packages/vendor-connectors/"
   />
 </CardGrid>
 

--- a/docs/src/content/docs/packages/vendor-connectors.mdx
+++ b/docs/src/content/docs/packages/vendor-connectors.mdx
@@ -21,7 +21,7 @@ import { Tabs, TabItem, Aside, Card, CardGrid } from '@astrojs/starlight/compone
     pip install vendor-connectors
     ```
   </TabItem>
-  <TabItem label="Vendor Extras">
+  <TabItem label="Service Extras">
     ```bash
     pip install vendor-connectors[aws]
     pip install vendor-connectors[google]
@@ -53,16 +53,16 @@ The `crewai` extra currently resolves to `crewai[tools] >= 1.14.2rc1` because th
 
 <CardGrid>
   <Card title="Cloud Connectors" icon="seti:cloud">
-    AWS, Google Cloud, Vault, and other service APIs with consistent connector patterns.
+    Typed clients for AWS, Google Cloud, GitHub, Slack, Vault, Zoom, Anthropic, Cursor, and Meshy.
   </Card>
   <Card title="AI Tool Adapters" icon="seti:graphql">
-    LangChain and CrewAI-compatible tool wrappers built from the same connector primitives.
+    Framework-ready tools exposed from the same connector primitives through `get_tools(...)`.
   </Card>
   <Card title="MCP Servers" icon="seti:config">
-    MCP entry points for clients such as Claude Desktop where the connector surface benefits from a tool server.
+    MCP entry points where a tool server makes sense, including the Meshy workflow surface.
   </Card>
   <Card title="Typed Core" icon="seti:python">
-    Shared input handling, retries, validation, and logging on top of the rest of the monorepo primitives.
+    Shared retries, validation, logging, and input handling inherited from the rest of the monorepo.
   </Card>
 </CardGrid>
 
@@ -80,6 +80,15 @@ slack = vc.get_slack_client()
 anthropic = vc.get_anthropic_client()
 ```
 
+### Framework Tools
+
+```python
+from vendor_connectors.meshy.tools import get_tools
+
+langchain_tools = get_tools("langchain")
+crewai_tools = get_tools("crewai")
+```
+
 ### Meshy MCP
 
 ```bash
@@ -87,37 +96,17 @@ pip install vendor-connectors[meshy,mcp]
 meshy-mcp
 ```
 
-### LangChain Tools
-
-```python
-from vendor_connectors.meshy.tools import get_langchain_tools
-
-tools = get_langchain_tools()
-```
-
-### CrewAI Tools
-
-```python
-from vendor_connectors.meshy.tools import get_crewai_tools
-
-tools = get_crewai_tools()
-```
-
 ---
 
-## Connectors
+## Integration Pattern
 
-| Connector | Direct API | LangChain Tools | CrewAI Tools | MCP |
-|-----------|------------|-----------------|--------------|-----|
-| AWS | ✅ | ✅ | ✅ | — |
-| Google Cloud | ✅ | ✅ | ✅ | — |
-| GitHub | ✅ | ✅ | ✅ | — |
-| Slack | ✅ | ✅ | ✅ | — |
-| Vault | ✅ | ✅ | ✅ | — |
-| Zoom | ✅ | ✅ | ✅ | — |
-| Meshy | ✅ | ✅ | ✅ | ✅ |
-| Anthropic | ✅ | ✅ | ✅ | — |
-| Cursor | ✅ | — | — | — |
+Most connectors expose the same three layers:
+
+- Direct Python clients for application code.
+- `get_tools(framework=...)` adapters for LangChain or CrewAI.
+- MCP entry points where the connector benefits from tool-server usage.
+
+Meshy is the broadest example because it supports all three surfaces. Other connectors expose the subset that makes sense for their API shape.
 
 ---
 

--- a/docs/src/content/docs/packages/vendor-connectors.mdx
+++ b/docs/src/content/docs/packages/vendor-connectors.mdx
@@ -1,0 +1,129 @@
+---
+title: Vendor Connectors
+description: Vendor integrations for cloud APIs, service APIs, AI tool adapters, and MCP servers
+---
+
+import { Tabs, TabItem, Aside, Card, CardGrid } from '@astrojs/starlight/components';
+
+**Vendor Connectors** (`vendor-connectors`) provides typed connectors for cloud providers, service APIs, AI tool adapters, and MCP server surfaces. Install only the vendors and framework extras you need, or use the full bundle when you want the entire integration surface available in one environment.
+
+[![PyPI](https://img.shields.io/pypi/v/vendor-connectors.svg)](https://pypi.org/project/vendor-connectors/)
+[![Python](https://img.shields.io/pypi/pyversions/vendor-connectors.svg)](https://pypi.org/project/vendor-connectors/)
+[![CI](https://github.com/jbcom/extended-data-library/workflows/CI/badge.svg)](https://github.com/jbcom/extended-data-library/actions)
+
+---
+
+## Installation
+
+<Tabs>
+  <TabItem label="Base Package">
+    ```bash
+    pip install vendor-connectors
+    ```
+  </TabItem>
+  <TabItem label="Vendor Extras">
+    ```bash
+    pip install vendor-connectors[aws]
+    pip install vendor-connectors[google]
+    pip install vendor-connectors[github]
+    pip install vendor-connectors[slack]
+    pip install vendor-connectors[vault]
+    pip install vendor-connectors[anthropic]
+    pip install vendor-connectors[meshy]
+    ```
+  </TabItem>
+  <TabItem label="AI + MCP Extras">
+    ```bash
+    pip install vendor-connectors[langchain]
+    pip install vendor-connectors[crewai]
+    pip install vendor-connectors[mcp]
+    pip install vendor-connectors[meshy,mcp]
+    pip install vendor-connectors[all]
+    ```
+  </TabItem>
+</Tabs>
+
+<Aside type="note">
+The `crewai` extra currently resolves to `crewai[tools] >= 1.14.2rc1` because that is the first upstream line carrying the patched `uv` and `requests` floors. Once CrewAI publishes the same fix on a stable release line, this package can move back to a stable minimum.
+</Aside>
+
+---
+
+## What You Get
+
+<CardGrid>
+  <Card title="Cloud Connectors" icon="seti:cloud">
+    AWS, Google Cloud, Vault, and other service APIs with consistent connector patterns.
+  </Card>
+  <Card title="AI Tool Adapters" icon="seti:graphql">
+    LangChain and CrewAI-compatible tool wrappers built from the same connector primitives.
+  </Card>
+  <Card title="MCP Servers" icon="seti:config">
+    MCP entry points for clients such as Claude Desktop where the connector surface benefits from a tool server.
+  </Card>
+  <Card title="Typed Core" icon="seti:python">
+    Shared input handling, retries, validation, and logging on top of the rest of the monorepo primitives.
+  </Card>
+</CardGrid>
+
+---
+
+## Quick Start
+
+```python
+from vendor_connectors import VendorConnectors
+
+vc = VendorConnectors()
+
+github = vc.get_github_client(github_owner="jbcom")
+slack = vc.get_slack_client()
+anthropic = vc.get_anthropic_client()
+```
+
+### Meshy MCP
+
+```bash
+pip install vendor-connectors[meshy,mcp]
+meshy-mcp
+```
+
+### LangChain Tools
+
+```python
+from vendor_connectors.meshy.tools import get_langchain_tools
+
+tools = get_langchain_tools()
+```
+
+### CrewAI Tools
+
+```python
+from vendor_connectors.meshy.tools import get_crewai_tools
+
+tools = get_crewai_tools()
+```
+
+---
+
+## Connectors
+
+| Connector | Direct API | LangChain Tools | CrewAI Tools | MCP |
+|-----------|------------|-----------------|--------------|-----|
+| AWS | ✅ | ✅ | ✅ | — |
+| Google Cloud | ✅ | ✅ | ✅ | — |
+| GitHub | ✅ | ✅ | ✅ | — |
+| Slack | ✅ | ✅ | ✅ | — |
+| Vault | ✅ | ✅ | ✅ | — |
+| Zoom | ✅ | ✅ | ✅ | — |
+| Meshy | ✅ | ✅ | ✅ | ✅ |
+| Anthropic | ✅ | ✅ | ✅ | — |
+| Cursor | ✅ | — | — | — |
+
+---
+
+## Related Links
+
+- [Package source](https://github.com/jbcom/extended-data-library/tree/main/packages/vendor-connectors)
+- [Changelog](https://github.com/jbcom/extended-data-library/blob/main/packages/vendor-connectors/CHANGELOG.md)
+- [API reference](/api/apidocs/vendor_connectors/vendor_connectors/)
+- [Getting started](/getting-started/)

--- a/docs/tests/unit/build.test.ts
+++ b/docs/tests/unit/build.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -7,13 +7,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const docsRoot = resolve(__dirname, '../..');
 const contentDir = resolve(docsRoot, 'src/content/docs');
 
-/**
- * Extract all sidebar items with slugs from the Astro config.
- * We parse the config file as text to avoid importing Astro internals in unit tests.
- */
-async function loadAstroConfig() {
-  const { default: config } = await import('../../astro.config.mjs');
-  return config;
+function loadAstroConfigSource(): string {
+  return readFileSync(resolve(docsRoot, 'astro.config.mjs'), 'utf-8');
 }
 
 /**
@@ -57,27 +52,21 @@ function resolveSlugToFile(slug: string): string | null {
 }
 
 describe('Astro configuration', () => {
-  it('can be imported without errors', async () => {
-    const config = await loadAstroConfig();
-    expect(config).toBeDefined();
-    expect(config.site).toBe('https://extended-data.dev');
+  it('defines the production site URL', () => {
+    const configSource = loadAstroConfigSource();
+    expect(configSource).toContain("site: 'https://extended-data.dev'");
   });
 
-  it('has Starlight integration configured', async () => {
-    const config = await loadAstroConfig();
-    expect(config.integrations).toBeDefined();
-    expect(config.integrations.length).toBeGreaterThan(0);
+  it('has Starlight integration configured', () => {
+    const configSource = loadAstroConfigSource();
+    expect(configSource).toContain("import starlight from '@astrojs/starlight'");
+    expect(configSource).toContain('starlight({');
   });
 });
 
 describe('Starlight sidebar structure', () => {
-  it('has sidebar groups defined', async () => {
-    const config = await loadAstroConfig();
-    const starlight = config.integrations[0];
-    // Starlight stores its config internally; we access it from the config source
-    // Re-import the raw config to extract sidebar
-    const { readFileSync } = await import('node:fs');
-    const configSource = readFileSync(resolve(docsRoot, 'astro.config.mjs'), 'utf-8');
+  it('has sidebar groups defined', () => {
+    const configSource = loadAstroConfigSource();
     expect(configSource).toContain('sidebar');
   });
 });

--- a/packages/vendor-connectors/README.md
+++ b/packages/vendor-connectors/README.md
@@ -36,11 +36,16 @@ pip install vendor-connectors
 ### Optional Extras
 
 ```bash
+pip install vendor-connectors[langchain]     # LangChain / LangGraph tool adapters
+pip install vendor-connectors[crewai]        # CrewAI tool adapters
+pip install vendor-connectors[meshy,mcp]     # Meshy MCP server support
 pip install vendor-connectors[webhooks]      # Meshy webhooks
-pip install vendor-connectors[meshy-crewai]  # CrewAI-specific features
-pip install vendor-connectors[meshy-mcp]     # Meshy MCP server
 pip install vendor-connectors[all]           # Everything
 ```
+
+> The `crewai` extra currently resolves to the first patched CrewAI line,
+> `1.14.2rc1+`, until upstream ships the same dependency floor in a stable
+> release.
 
 ## Quick Start
 
@@ -113,11 +118,11 @@ from vendor_connectors.meshy.mcp import run_server
 
 ## Contributing
 
-Contributions are welcome! Please see the [Contributing Guidelines](https://github.com/jbcom/extended-data-library/blob/main/CONTRIBUTING.md) for more information.
+Contributions are welcome! Please see the [Contributing Guidelines](https://github.com/jbcom/extended-data-library/blob/main/docs/development/contributing.md) for more information.
 
 ## Project Links
 
 - [**PyPI**](https://pypi.org/project/vendor-connectors/)
 - [**GitHub**](https://github.com/jbcom/extended-data-library/tree/main/packages/vendor-connectors)
-- [**Documentation**](https://extendeddata.dev)
+- [**Documentation**](https://extendeddata.dev/packages/vendor-connectors/)
 - [**Changelog**](https://github.com/jbcom/extended-data-library/blob/main/packages/vendor-connectors/CHANGELOG.md)

--- a/packages/vendor-connectors/examples/README.md
+++ b/packages/vendor-connectors/examples/README.md
@@ -15,6 +15,10 @@ pip install vendor-connectors[aws,google,meshy]
 
 # For AI framework integration
 pip install vendor-connectors[langchain]
+pip install vendor-connectors[crewai]
+
+# For the Meshy MCP server
+pip install vendor-connectors[meshy,mcp]
 ```
 
 ## Examples

--- a/packages/vendor-connectors/pyproject.toml
+++ b/packages/vendor-connectors/pyproject.toml
@@ -34,17 +34,17 @@ dependencies = [
     "httpx>=0.28.1",
     "tenacity>=8.4.1",
     "pydantic>=2.11.9",
-    "requests>=2.32.5",
+    "requests>=2.33.0",
     # Utilities
     "deepmerge>=2.0",
     "more-itertools>=11.0.2",
 ]
 
 [project.urls]
-Documentation = "https://extendeddata.dev"
-Issues = "https://github.com/extended-data-library/extended-data-types/issues"
-Source = "https://github.com/extended-data-library/extended-data-types"
-Changelog = "https://github.com/extended-data-library/extended-data-types/blob/main/packages/vendor-connectors/CHANGELOG.md"
+Documentation = "https://extendeddata.dev/packages/vendor-connectors/"
+Issues = "https://github.com/jbcom/extended-data-library/issues"
+Source = "https://github.com/jbcom/extended-data-library/tree/main/packages/vendor-connectors"
+Changelog = "https://github.com/jbcom/extended-data-library/blob/main/packages/vendor-connectors/CHANGELOG.md"
 
 [project.optional-dependencies]
 # === Vendor Connector Extras (install what you need) ===
@@ -98,10 +98,16 @@ secrets = [
 # LangChain, LangGraph, and any framework that uses LangChain tool format.
 langchain = [
     "langchain-core>=1.2.28",
+    # Intentionally pinned here to enforce the safe transitive minimum used by `langchain-core`.
+    "langsmith>=0.7.31",
 ]
 # CrewAI tools support
 crewai = [
-    "crewai[tools]>=1.14.1",
+    # `1.14.2rc1` is the first CrewAI line that carries the patched `uv`
+    # and `requests` transitive requirements.
+    "crewai[tools]>=1.14.2rc1",
+    # Intentionally pinned here to enforce the safe transitive minimum used by `crewai`.
+    "uv>=0.11.6",
 ]
 # AWS Strands agents support
 strands = [
@@ -114,7 +120,9 @@ mcp = [
 # All AI frameworks
 ai = [
     "langchain-core>=1.2.28",
-    "crewai[tools]>=1.14.1",
+    "langsmith>=0.7.31",
+    "crewai[tools]>=1.14.2rc1",
+    "uv>=0.11.6",
     "strands-agents>=1.35.0",
     "mcp>=1.26.0",
 ]
@@ -161,6 +169,7 @@ tests-e2e-langchain = [
     "pytest-vcr>=1.0.2",
     "vcrpy>=8.1.1",
     "langchain-core>=1.2.28",
+    "langsmith>=0.7.31",
     "langchain-anthropic>=1.4.0",
     "langgraph>=1.1.6",
 ]
@@ -173,7 +182,8 @@ tests-e2e-crewai = [
     "pytest-timeout>=2.4.0",
     "pytest-vcr>=1.0.2",
     "vcrpy>=8.1.1",
-    "crewai[tools]>=1.14.1",
+    "crewai[tools]>=1.14.2rc1",
+    "uv>=0.11.6",
 ]
 # E2E tests for Strands
 tests-e2e-strands = [
@@ -196,9 +206,11 @@ tests-e2e-all = [
     "pytest-vcr>=1.0.2",
     "vcrpy>=8.1.1",
     "langchain-core>=1.2.28",
+    "langsmith>=0.7.31",
     "langchain-anthropic>=1.4.0",
     "langgraph>=1.1.6",
-    "crewai[tools]>=1.14.1",
+    "crewai[tools]>=1.14.2rc1",
+    "uv>=0.11.6",
     "strands-agents>=1.35.0",
 ]
 
@@ -241,7 +253,9 @@ all = [
     "filelock>=3.25.2",
     # AI frameworks
     "langchain-core>=1.2.28",
-    "crewai[tools]>=1.14.1",
+    "langsmith>=0.7.31",
+    "crewai[tools]>=1.14.2rc1",
+    "uv>=0.11.6",
     "strands-agents>=1.35.0",
     "mcp>=1.26.0",
     # Features

--- a/packages/vendor-connectors/src/vendor_connectors/meshy/mcp.py
+++ b/packages/vendor-connectors/src/vendor_connectors/meshy/mcp.py
@@ -43,7 +43,7 @@ def _create_mcp_tools() -> list[Any]:
     try:
         from mcp.types import Tool
     except ImportError as e:
-        msg = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy-mcp]"
+        msg = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy,mcp]"
         raise ImportError(msg) from e
 
     # Import Meshy tool functions
@@ -263,7 +263,7 @@ def create_server():
     try:
         from mcp.server import Server
     except ImportError as e:
-        msg = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy-mcp]"
+        msg = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy,mcp]"
         raise ImportError(msg) from e
 
     server = Server("meshy-ai")
@@ -317,7 +317,7 @@ def run_server(server=None):
     try:
         from mcp.server.stdio import stdio_server
     except ImportError as e:
-        msg = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy-mcp]"
+        msg = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy,mcp]"
         raise ImportError(msg) from e
 
     if server is None:

--- a/packages/vendor-connectors/src/vendor_connectors/meshy/mcp.py
+++ b/packages/vendor-connectors/src/vendor_connectors/meshy/mcp.py
@@ -34,6 +34,9 @@ import json
 from typing import Any
 
 
+MCP_INSTALL_MESSAGE = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy,mcp]"
+
+
 def _create_mcp_tools() -> list[Any]:
     """Create MCP tool definitions from Meshy functions.
 
@@ -43,8 +46,7 @@ def _create_mcp_tools() -> list[Any]:
     try:
         from mcp.types import Tool
     except ImportError as e:
-        msg = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy,mcp]"
-        raise ImportError(msg) from e
+        raise ImportError(MCP_INSTALL_MESSAGE) from e
 
     # Import Meshy tool functions
     from vendor_connectors.meshy import tools
@@ -263,8 +265,7 @@ def create_server():
     try:
         from mcp.server import Server
     except ImportError as e:
-        msg = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy,mcp]"
-        raise ImportError(msg) from e
+        raise ImportError(MCP_INSTALL_MESSAGE) from e
 
     server = Server("meshy-ai")
 
@@ -317,8 +318,7 @@ def run_server(server=None):
     try:
         from mcp.server.stdio import stdio_server
     except ImportError as e:
-        msg = "MCP SDK not installed. Install with: pip install vendor-connectors[meshy,mcp]"
-        raise ImportError(msg) from e
+        raise ImportError(MCP_INSTALL_MESSAGE) from e
 
     if server is None:
         server = create_server()

--- a/uv.lock
+++ b/uv.lock
@@ -807,7 +807,7 @@ toml = [
 
 [[package]]
 name = "crewai"
-version = "1.14.1"
+version = "1.14.2rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -841,9 +841,9 @@ dependencies = [
     { name = "tomli-w" },
     { name = "uv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/17/508e239669b1d5349eb816fdc06800d34f1d9c95b0f0c780da78d58db3a3/crewai-1.14.1.tar.gz", hash = "sha256:7e1a22b41f673a2f157e802a258e948d22eb8fc5a2411add81efa4c0b295a3a8", size = 7793182, upload-time = "2026-04-08T17:57:51.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/0d/5d37c6a8667ad34f20cd989cd5f3283d08e3221756321075a46cdc342df3/crewai-1.14.2rc1.tar.gz", hash = "sha256:92f1e939edea0fbf8fb10d1bc574e4065897d667f1884cb30070c082756a3d51", size = 7817139, upload-time = "2026-04-15T21:25:52.318Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/3c/c6df7b10e877a42cf1ec43323fd26668d1fb97241bbb3be640f3c6d5b19f/crewai-1.14.1-py3-none-any.whl", hash = "sha256:e33b9bd57f45f6f3f9d15fd583a46bc9cd62afb5a8c3b63fa6dab9e6bd337937", size = 1044196, upload-time = "2026-04-08T17:57:49.373Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a6/ae4290322364a11cdcffc21a17102b90433b9c766a143dd3a5c0555292bd/crewai-1.14.2rc1-py3-none-any.whl", hash = "sha256:daf9681c1c31044e66783e98d1ab33f1f2b1cab69dce9b2e4007761fcd4980b5", size = 1059844, upload-time = "2026-04-15T21:25:50.282Z" },
 ]
 
 [package.optional-dependencies]
@@ -853,7 +853,7 @@ tools = [
 
 [[package]]
 name = "crewai-tools"
-version = "1.14.1"
+version = "1.14.2rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -865,9 +865,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "youtube-transcript-api" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/65/3528c77f327b699e18ff90a0dddc5bb9bf6ab8f6392945fdcc5196f0c776/crewai_tools-1.14.1.tar.gz", hash = "sha256:2e24e062aa37acf93a7cdec6e514ecee08c7819a2f2f51c9ab85d172376fe691", size = 866279, upload-time = "2026-04-08T17:57:58.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/86/8ff9b7200d243b56e2b1fbd4d3b1fa4101d86b1a8ea0632015bc5435c2c3/crewai_tools-1.14.2rc1.tar.gz", hash = "sha256:fd009c34207d9106fa1c14ac5156ac69cf77c6f8db9f03824bac36993851ed94", size = 874774, upload-time = "2026-04-15T21:25:58.142Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/a5/f517e288d91cd9ca61541d9873af113e9e6ce2a8727c26ce797c47778c62/crewai_tools-1.14.1-py3-none-any.whl", hash = "sha256:ad0c6c2145c9958afd7c70e6160911acc390c2256485549e29cdcf4d977854a2", size = 779912, upload-time = "2026-04-08T17:57:56.358Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e7/b9b81e0788cabe971e3b06304d51a4d3d6394d68333776a663fcb91ebc4a/crewai_tools-1.14.2rc1-py3-none-any.whl", hash = "sha256:6c94aa0fa38719ff7dff0b59dc4342bc10aa1148a314470f9a1f4c6371bc8a00", size = 784238, upload-time = "2026-04-15T21:25:56.341Z" },
 ]
 
 [[package]]
@@ -1173,7 +1173,7 @@ dev = [
 
 [[package]]
 name = "extended-data-types"
-version = "6.2.0"
+version = "6.2.1"
 source = { editable = "packages/extended-data-types" }
 dependencies = [
     { name = "deepmerge" },
@@ -2305,7 +2305,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.6"
+version = "0.7.32"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2318,9 +2318,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/b1/a1514b6fe33dc956bee1e6aba88470999d53a6ed02ec8fd14d6d409b8fb7/langsmith-0.7.6.tar.gz", hash = "sha256:e8646f8429d3c1641c7bae3c01bfdc3dfa27625994b0ef4303714d6b06fe1ef9", size = 1041741, upload-time = "2026-02-21T01:26:34.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/a0b4a501bee6b8a741ce29f8c48155b132118483cddc6f9247735ddb38fa/langsmith-0.7.32.tar.gz", hash = "sha256:b59b8e106d0e4c4842e158229296086e2aa7c561e3f602acda73d3ad0062e915", size = 1184518, upload-time = "2026-04-15T23:42:41.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/47/9865e5f0c49d74e3f4ea5697dadf11f2b9c9ae037f0bff599583ebe59189/langsmith-0.7.6-py3-none-any.whl", hash = "sha256:28d256584969db723b68189a7dbb065836572728ab4d9597ec5379fe0a1e1641", size = 325475, upload-time = "2026-02-21T01:26:32.504Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bc/148f98ac7dad73ac5e1b1c985290079cfeeb9ba13d760a24f25002beb2c9/langsmith-0.7.32-py3-none-any.whl", hash = "sha256:e1fde928990c4c52f47dc5132708cec674355d9101723d564183e965f383bf5f", size = 378272, upload-time = "2026-04-15T23:42:39.905Z" },
 ]
 
 [[package]]
@@ -5106,7 +5106,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -5114,9 +5114,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -6408,28 +6408,28 @@ wheels = [
 
 [[package]]
 name = "uv"
-version = "0.9.30"
+version = "0.11.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/a0/63cea38fe839fb89592728b91928ee6d15705f1376a7940fee5bbc77fea0/uv-0.9.30.tar.gz", hash = "sha256:03ebd4b22769e0a8d825fa09d038e31cbab5d3d48edf755971cb0cec7920ab95", size = 3846526, upload-time = "2026-02-04T21:45:37.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/7d/17750123a8c8e324627534fe1ae2e7a46689db8492f1a834ab4fd229a7d8/uv-0.11.7.tar.gz", hash = "sha256:46d971489b00bdb27e0aa715e4a5cd4ef2c28ea5b6ef78f2b67bf861eb44b405", size = 4083385, upload-time = "2026-04-15T21:42:55.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/3c/71be72f125f0035348b415468559cc3b335ec219376d17a3d242d2bd9b23/uv-0.9.30-py3-none-linux_armv6l.whl", hash = "sha256:a5467dddae1cd5f4e093f433c0f0d9a0df679b92696273485ec91bbb5a8620e6", size = 21927585, upload-time = "2026-02-04T21:46:14.935Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/fd/8070b5423a77d4058d14e48a970aa075762bbff4c812dda3bb3171543e44/uv-0.9.30-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6ec38ae29aa83a37c6e50331707eac8ecc90cf2b356d60ea6382a94de14973be", size = 21050392, upload-time = "2026-02-04T21:45:55.649Z" },
-    { url = "https://files.pythonhosted.org/packages/42/5f/3ccc9415ef62969ed01829572338ea7bdf4c5cf1ffb9edc1f8cb91b571f3/uv-0.9.30-py3-none-macosx_11_0_arm64.whl", hash = "sha256:777ecd117cf1d8d6bb07de8c9b7f6c5f3e802415b926cf059d3423699732eb8c", size = 19817085, upload-time = "2026-02-04T21:45:40.881Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/3f/76b44e2a224f4c4a8816fc92686ef6d4c2656bc5fc9d4f673816162c994d/uv-0.9.30-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:93049ba3c41fa2cc38b467cb78ef61b2ddedca34b6be924a5481d7750c8111c6", size = 21620537, upload-time = "2026-02-04T21:45:47.846Z" },
-    { url = "https://files.pythonhosted.org/packages/60/2a/50f7e8c6d532af8dd327f77bdc75ce4652322ac34f5e29f79a8e04ea3cc8/uv-0.9.30-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:f295604fee71224ebe2685a0f1f4ff7a45c77211a60bd57133a4a02056d7c775", size = 21550855, upload-time = "2026-02-04T21:46:26.269Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/10/f823d4af1125fae559194b356757dc7d4a8ac79d10d11db32c2d4c9e2f63/uv-0.9.30-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2faf84e1f3b6fc347a34c07f1291d11acf000b0dd537a61d541020f22b17ccd9", size = 21516576, upload-time = "2026-02-04T21:46:03.494Z" },
-    { url = "https://files.pythonhosted.org/packages/91/f3/64b02db11f38226ed34458c7fbdb6f16b6d4fd951de24c3e51acf02b30f8/uv-0.9.30-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b3b3700ecf64a09a07fd04d10ec35f0973ec15595d38bbafaa0318252f7e31f", size = 22718097, upload-time = "2026-02-04T21:45:51.875Z" },
-    { url = "https://files.pythonhosted.org/packages/28/21/a48d1872260f04a68bb5177b0f62ddef62ab892d544ed1922f2d19fd2b00/uv-0.9.30-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:b176fc2937937dd81820445cb7e7e2e3cd1009a003c512f55fa0ae10064c8a38", size = 24107844, upload-time = "2026-02-04T21:46:19.032Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/c6/d7e5559bfe1ab7a215a7ad49c58c8a5701728f2473f7f436ef00b4664e88/uv-0.9.30-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:180e8070b8c438b9a3fb3fde8a37b365f85c3c06e17090f555dc68fdebd73333", size = 23685378, upload-time = "2026-02-04T21:46:07.166Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/bf/b937bbd50d14c6286e353fd4c7bdc09b75f6b3a26bd4e2f3357e99891f28/uv-0.9.30-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4125a9aa2a751e1589728f6365cfe204d1be41499148ead44b6180b7df576f27", size = 22848471, upload-time = "2026-02-04T21:45:18.728Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/57/12a67c569e69b71508ad669adad266221f0b1d374be88eaf60109f551354/uv-0.9.30-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4366dd740ac9ad3ec50a58868a955b032493bb7d7e6ed368289e6ced8bbc70f3", size = 22774258, upload-time = "2026-02-04T21:46:10.798Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b8/a26cc64685dddb9fb13f14c3dc1b12009f800083405f854f84eb8c86b494/uv-0.9.30-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:33e50f208e01a0c20b3c5f87d453356a5cbcfd68f19e47a28b274cd45618881c", size = 21699573, upload-time = "2026-02-04T21:45:44.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/59/995af0c5f0740f8acb30468e720269e720352df1d204e82c2d52d9a8c586/uv-0.9.30-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5e7a6fa7a3549ce893cf91fe4b06629e3e594fc1dca0a6050aba2ea08722e964", size = 22460799, upload-time = "2026-02-04T21:45:26.658Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/0b/6affe815ecbaebf38b35d6230fbed2f44708c67d5dd5720f81f2ec8f96ff/uv-0.9.30-py3-none-musllinux_1_1_i686.whl", hash = "sha256:62d7e408d41e392b55ffa4cf9b07f7bbd8b04e0929258a42e19716c221ac0590", size = 22001777, upload-time = "2026-02-04T21:45:34.656Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/b6/47a515171c891b0d29f8e90c8a1c0e233e4813c95a011799605cfe04c74c/uv-0.9.30-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6dc65c24f5b9cdc78300fa6631368d3106e260bbffa66fb1e831a318374da2df", size = 22968416, upload-time = "2026-02-04T21:45:22.863Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/3a/c1df8615385138bb7c43342586431ca32b77466c5fb086ac0ed14ab6ca28/uv-0.9.30-py3-none-win32.whl", hash = "sha256:74e94c65d578657db94a753d41763d0364e5468ec0d368fb9ac8ddab0fb6e21f", size = 20889232, upload-time = "2026-02-04T21:46:22.617Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/a8/e8761c8414a880d70223723946576069e042765475f73b4436d78b865dba/uv-0.9.30-py3-none-win_amd64.whl", hash = "sha256:88a2190810684830a1ba4bb1cf8fb06b0308988a1589559404259d295260891c", size = 23432208, upload-time = "2026-02-04T21:45:30.85Z" },
-    { url = "https://files.pythonhosted.org/packages/49/e8/6f2ebab941ec559f97110bbbae1279cd0333d6bc352b55f6fa3fefb020d9/uv-0.9.30-py3-none-win_arm64.whl", hash = "sha256:7fde83a5b5ea027315223c33c30a1ab2f2186910b933d091a1b7652da879e230", size = 21887273, upload-time = "2026-02-04T21:45:59.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5b/2bb2ab6fe6c78c2be10852482ef0cae5f3171460a6e5e24c32c9a0843163/uv-0.11.7-py3-none-linux_armv6l.whl", hash = "sha256:f422d39530516b1dfb28bb6e90c32bb7dacd50f6a383cd6e40c1a859419fbc8c", size = 23757265, upload-time = "2026-04-15T21:43:14.494Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f5/36ff27b01e60a88712628c8a5a6003b8e418883c24e084e506095844a797/uv-0.11.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8b2fe1ec6775dad10183e3fdce430a5b37b7857d49763c884f3a67eaa8ca6f8a", size = 23184529, upload-time = "2026-04-15T21:42:30.225Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/f379be661316698f877e78f4c51e5044be0b6f390803387237ad92c4057f/uv-0.11.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:162fa961a9a081dcea6e889c79f738a5ae56507047e4672964972e33c301bea9", size = 21780167, upload-time = "2026-04-15T21:42:44.942Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/fbed29775b0612f4f5679d3226268f1a347161abc1727b4080fb41d9f46f/uv-0.11.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5985a15a92bd9a170fc1947abb1fbc3e9828c5a430ad85b5bed8356c20b67a71", size = 23609640, upload-time = "2026-04-15T21:42:22.57Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/de/989a69634a869a22322770120557c2d8cbba5b77ec7cfad326b4ec0f0547/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:fab0bb43fbbc0ee5b5fee212078d2300c371b725faff7cf72eeaafa0bff0606b", size = 23322484, upload-time = "2026-04-15T21:43:26.52Z" },
+    { url = "https://files.pythonhosted.org/packages/24/08/c1af05ea602eb4eb75d86badb6b0594cc104c3ca83ccf06d9ed4dd2186ad/uv-0.11.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:23d457d6731ebdb83f1bffebe4894edab2ef43c1ec5488433c74300db4958924", size = 23326385, upload-time = "2026-04-15T21:42:41.32Z" },
+    { url = "https://files.pythonhosted.org/packages/68/99/e246962da06383e992ecab55000c62a50fb36efef855ea7264fad4816bf4/uv-0.11.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d6a17507b8139b8803f445a03fd097f732ce8356b1b7b13cdb4dd8ef7f4b2e0", size = 24985751, upload-time = "2026-04-15T21:42:37.777Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/b0b68083859579ce811996c1480765ec6a2442b44c451eaef53e6218fbae/uv-0.11.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd48823ca4b505124389f49ae50626ba9f57212b9047738efc95126ed5f3844d", size = 25724160, upload-time = "2026-04-15T21:43:18.762Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/19/5970e89d9e458fd3c4966bbc586a685a1c0ab0a8bf334503f63fa20b925b/uv-0.11.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb91f52ee67e10d5290f2c2897e2171357f1a10966de38d83eefa93d96843b0c", size = 25028512, upload-time = "2026-04-15T21:43:02.721Z" },
+    { url = "https://files.pythonhosted.org/packages/83/eb/4e1557daf6693cb446ed28185664ad6682fd98c6dbac9e433cbc35df450a/uv-0.11.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e4d5e31bea86e1b6e0f5a0f95e14e80018e6f6c0129256d2915a4b3d793644d", size = 24933975, upload-time = "2026-04-15T21:42:18.828Z" },
+    { url = "https://files.pythonhosted.org/packages/68/55/3b517ec8297f110d6981f525cccf26f86e30883fbb9c282769cffbcdcfca/uv-0.11.7-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:ceae53b202ea92bc954759bc7c7570cdcd5c3512fce15701198c19fd2dfb8605", size = 23706403, upload-time = "2026-04-15T21:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/30/7d93a0312d60e147722967036dc8ea37baab4802784bddc22464cb707deb/uv-0.11.7-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:f97e9f4e4d44fb5c4dfaa05e858ef3414a96416a2e4af270ecd88a3e5fb049a9", size = 24495797, upload-time = "2026-04-15T21:42:26.538Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/89/d49480bdab7725d36982793857e461d471bde8e1b7f438ffccee677a7bf8/uv-0.11.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:750ee5b96959b807cf442b73dd8b55111862d63f258f896787ea5f06b68aaca9", size = 24580471, upload-time = "2026-04-15T21:42:52.871Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/9f/c57dc03b48be17b564e304eb9ff982890c12dfb888b1ce370788733329ab/uv-0.11.7-py3-none-musllinux_1_1_i686.whl", hash = "sha256:f394331f0507e80ee732cb3df737589de53bed999dd02a6d24682f08c2f8ac4f", size = 24113637, upload-time = "2026-04-15T21:42:34.094Z" },
+    { url = "https://files.pythonhosted.org/packages/13/ba/b87e358b629a68258527e3490e73b7b148770f4d2257842dea3b7981d4e8/uv-0.11.7-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0df59ab0c6a4b14a763e8445e1c303af9abeb53cdfa4428daf9ff9642c0a3cce", size = 25119850, upload-time = "2026-04-15T21:43:22.529Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/74/16d229e1d8574bcbafa6dc643ac20b70c3e581f42ac31a6f4fd53035ffe3/uv-0.11.7-py3-none-win32.whl", hash = "sha256:553e67cc766d013ce24353fecd4ea5533d2aedcfd35f9fac430e07b1d1f23ed4", size = 22918454, upload-time = "2026-04-15T21:42:58.702Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/1d/b73e473da616ac758b8918fb218febcc46ddf64cba9e03894dfa226b28bd/uv-0.11.7-py3-none-win_amd64.whl", hash = "sha256:5674dfb5944513f4b3735b05c2deba6b1b01151f46729d533d413a9a905f8c5d", size = 25447744, upload-time = "2026-04-15T21:42:48.813Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/e6bfdea92ed270f3445a5a3c17599d041b3f2dbc5026c09e02830a03bbaf/uv-0.11.7-py3-none-win_arm64.whl", hash = "sha256:6158b7e39464f1aa1e040daa0186cae4749a78b5cd80ac769f32ca711b8976b1", size = 23941816, upload-time = "2026-04-15T21:43:06.732Z" },
 ]
 
 [[package]]
@@ -6525,7 +6525,7 @@ wheels = [
 
 [[package]]
 name = "vendor-connectors"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "packages/vendor-connectors" }
 dependencies = [
     { name = "deepmerge" },
@@ -6543,8 +6543,10 @@ dependencies = [
 ai = [
     { name = "crewai", extra = ["tools"] },
     { name = "langchain-core" },
+    { name = "langsmith" },
     { name = "mcp" },
     { name = "strands-agents" },
+    { name = "uv" },
 ]
 all = [
     { name = "anthropic" },
@@ -6557,6 +6559,7 @@ all = [
     { name = "google-cloud-resource-manager" },
     { name = "hvac" },
     { name = "langchain-core" },
+    { name = "langsmith" },
     { name = "mcp" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -6568,6 +6571,7 @@ all = [
     { name = "slack-sdk" },
     { name = "sqlite-vec" },
     { name = "strands-agents" },
+    { name = "uv" },
     { name = "uvicorn" },
     { name = "validators" },
 ]
@@ -6579,6 +6583,7 @@ aws = [
 ]
 crewai = [
     { name = "crewai", extra = ["tools"] },
+    { name = "uv" },
 ]
 dev = [
     { name = "beautifulsoup4" },
@@ -6612,6 +6617,7 @@ google = [
 ]
 langchain = [
     { name = "langchain-core" },
+    { name = "langsmith" },
 ]
 mcp = [
     { name = "mcp" },
@@ -6653,6 +6659,7 @@ tests-e2e-all = [
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langgraph" },
+    { name = "langsmith" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -6660,6 +6667,7 @@ tests-e2e-all = [
     { name = "pytest-timeout" },
     { name = "pytest-vcr" },
     { name = "strands-agents" },
+    { name = "uv" },
     { name = "vcrpy" },
 ]
 tests-e2e-crewai = [
@@ -6670,12 +6678,14 @@ tests-e2e-crewai = [
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
     { name = "pytest-vcr" },
+    { name = "uv" },
     { name = "vcrpy" },
 ]
 tests-e2e-langchain = [
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langgraph" },
+    { name = "langsmith" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -6714,11 +6724,11 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'dev'", specifier = ">=4.13.4" },
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.42.89" },
     { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.42.89" },
-    { name = "crewai", extras = ["tools"], marker = "extra == 'ai'", specifier = ">=1.14.1" },
-    { name = "crewai", extras = ["tools"], marker = "extra == 'all'", specifier = ">=1.14.1" },
-    { name = "crewai", extras = ["tools"], marker = "extra == 'crewai'", specifier = ">=1.14.1" },
-    { name = "crewai", extras = ["tools"], marker = "extra == 'tests-e2e-all'", specifier = ">=1.14.1" },
-    { name = "crewai", extras = ["tools"], marker = "extra == 'tests-e2e-crewai'", specifier = ">=1.14.1" },
+    { name = "crewai", extras = ["tools"], marker = "extra == 'ai'", specifier = ">=1.14.2rc1" },
+    { name = "crewai", extras = ["tools"], marker = "extra == 'all'", specifier = ">=1.14.2rc1" },
+    { name = "crewai", extras = ["tools"], marker = "extra == 'crewai'", specifier = ">=1.14.2rc1" },
+    { name = "crewai", extras = ["tools"], marker = "extra == 'tests-e2e-all'", specifier = ">=1.14.2rc1" },
+    { name = "crewai", extras = ["tools"], marker = "extra == 'tests-e2e-crewai'", specifier = ">=1.14.2rc1" },
     { name = "deepmerge", specifier = ">=2.0" },
     { name = "directed-inputs-class", editable = "packages/directed-inputs-class" },
     { name = "extended-data-types", editable = "packages/extended-data-types" },
@@ -6744,6 +6754,11 @@ requires-dist = [
     { name = "langchain-core", marker = "extra == 'tests-e2e-langchain'", specifier = ">=1.2.28" },
     { name = "langgraph", marker = "extra == 'tests-e2e-all'", specifier = ">=1.1.6" },
     { name = "langgraph", marker = "extra == 'tests-e2e-langchain'", specifier = ">=1.1.6" },
+    { name = "langsmith", marker = "extra == 'ai'", specifier = ">=0.7.31" },
+    { name = "langsmith", marker = "extra == 'all'", specifier = ">=0.7.31" },
+    { name = "langsmith", marker = "extra == 'langchain'", specifier = ">=0.7.31" },
+    { name = "langsmith", marker = "extra == 'tests-e2e-all'", specifier = ">=0.7.31" },
+    { name = "langsmith", marker = "extra == 'tests-e2e-langchain'", specifier = ">=0.7.31" },
     { name = "lifecyclelogging", editable = "packages/lifecyclelogging" },
     { name = "mcp", marker = "extra == 'ai'", specifier = ">=1.26.0" },
     { name = "mcp", marker = "extra == 'all'", specifier = ">=1.26.0" },
@@ -6800,7 +6815,7 @@ requires-dist = [
     { name = "python-graphql-client", marker = "extra == 'all'", specifier = ">=0.4.3" },
     { name = "python-graphql-client", marker = "extra == 'github'", specifier = ">=0.4.3" },
     { name = "pyyaml", marker = "extra == 'secrets'", specifier = ">=6.0.3" },
-    { name = "requests", specifier = ">=2.32.5" },
+    { name = "requests", specifier = ">=2.33.0" },
     { name = "rich", marker = "extra == 'all'", specifier = ">=13.7.0" },
     { name = "rich", marker = "extra == 'dev'", specifier = ">=13.7.0" },
     { name = "rich", marker = "extra == 'meshy'", specifier = ">=13.7.0" },
@@ -6820,6 +6835,11 @@ requires-dist = [
     { name = "strands-agents", marker = "extra == 'tests-e2e-strands'", specifier = ">=1.35.0" },
     { name = "tenacity", specifier = ">=8.4.1" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.33.0.20260408" },
+    { name = "uv", marker = "extra == 'ai'", specifier = ">=0.11.6" },
+    { name = "uv", marker = "extra == 'all'", specifier = ">=0.11.6" },
+    { name = "uv", marker = "extra == 'crewai'", specifier = ">=0.11.6" },
+    { name = "uv", marker = "extra == 'tests-e2e-all'", specifier = ">=0.11.6" },
+    { name = "uv", marker = "extra == 'tests-e2e-crewai'", specifier = ">=0.11.6" },
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.44.0" },
     { name = "uvicorn", marker = "extra == 'webhooks'", specifier = ">=0.44.0" },
     { name = "validators", marker = "extra == 'all'", specifier = ">=0.35.0" },


### PR DESCRIPTION
## Summary
- remediate the open `langsmith`, `requests`, and `uv` dependency alerts in the workspace lock and connector extras
- align `vendor-connectors` package metadata and README/docs with the actual extras and live docs routes
- add a first-class Vendor Connectors package page and fix stale site links that pointed at a nonexistent route

## Details
- raise the core `requests` floor to `>=2.33.0`
- pin `langsmith>=0.7.31` anywhere `langchain-core` is part of the public extra surface
- move the CrewAI extra to `crewai[tools]>=1.14.2rc1` and `uv>=0.11.6`
  - this is the first upstream CrewAI line carrying the patched `uv` constraint
  - stable `1.14.1` still forces `uv~=0.9.13`, so there is not a stable-only path that clears the `uv` alert today
- fix Meshy MCP install guidance to use `vendor-connectors[meshy,mcp]`
- correct package URLs and add a `packages/vendor-connectors` docs page

## Validation
- `tox -e lint`
- `uv build --package vendor-connectors`
- `tox -e connectors`
- `tox -e docs && bash tools/sphinx-to-astro.sh && cd docs && npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Vendor Connectors package documentation page with installation instructions and quick-start examples
  * Updated navigation links across documentation to point to Vendor Connectors package overview

* **New Features**
  * Added new optional installation extras: `langchain`, `crewai`, and `meshy,mcp` for AI framework integrations

* **Chores**
  * Updated dependency versions and added LangSmith support
  * Updated project URLs and contribution documentation paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->