### PR TITLE
docs(secretssync): align package docs to monorepo

### DIFF
--- a/packages/secretssync/CONTRIBUTING.md
+++ b/packages/secretssync/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Be respectful, inclusive, and professional. We're all here to learn and improve 
 
 ### Suggesting Features
 
-1. **Check existing requests**: Search issues and discussions
+1. **Check existing requests**: Search existing issues first
 2. **Describe the use case**: Why is this needed?
 3. **Propose a solution**: How should it work?
 4. **Consider alternatives**: What workarounds exist today?
@@ -28,8 +28,8 @@ Be respectful, inclusive, and professional. We're all here to learn and improve 
 
 1. **Fork the repository**
    ```bash
-   git clone https://github.com/YOUR_USERNAME/secretsync.git
-   cd secretsync
+   git clone https://github.com/YOUR_USERNAME/extended-data-library.git
+   cd extended-data-library/packages/secretssync
    ```
 
 2. **Create a feature branch**
@@ -233,7 +233,7 @@ To add support for a new secret store:
    ```go
    package newstore
    
-   import "github.com/extended-data-library/secretssync/pkg/store"
+   import "github.com/jbcom/extended-data-library/packages/secretssync/pkg/store"
    
    type Store struct {
        // configuration fields
@@ -283,8 +283,7 @@ Releases are managed by maintainers:
 ## Getting Help
 
 - **Documentation**: Read the [docs/](./docs/) directory
-- **Discussions**: Use [GitHub Discussions](https://github.com/extended-data-library/secretssync/discussions)
-- **Issues**: For bugs and features, use [GitHub Issues](https://github.com/extended-data-library/secretssync/issues)
+- **Issues**: Use [GitHub Issues](https://github.com/jbcom/extended-data-library/issues) for bugs, questions, and feature requests
 
 ## License
 

--- a/packages/secretssync/README.md
+++ b/packages/secretssync/README.md
@@ -117,12 +117,12 @@ See [Two-Phase Architecture](./docs/TWO_PHASE_ARCHITECTURE.md) for detailed docu
 
 ```bash
 # Go install
-go install github.com/jbcom/extended-data-library/cmd/secretsync@latest
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
 
-# Or download binary from releases
-curl -LO https://github.com/jbcom/extended-data-library/releases/latest/download/secretsync-linux-amd64
-chmod +x secretsync-linux-amd64
-sudo mv secretsync-linux-amd64 /usr/local/bin/secretsync
+# Or build from a local checkout
+git clone https://github.com/jbcom/extended-data-library.git
+cd extended-data-library/packages/secretssync
+make build
 ```
 
 ## Python Bindings
@@ -284,7 +284,7 @@ SecretSync is available as a GitHub Action for seamless CI/CD integration:
 
 ```yaml
 - name: Sync Secrets
-  uses: jbcom/extended-data-library/packages/secretssync@v1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
     dry-run: 'false'
@@ -501,8 +501,7 @@ For detailed documentation, see [tests/integration/README.md](./tests/integratio
 
 ### Getting Help
 - **📚 Documentation**: Comprehensive guides and examples
-- **💬 GitHub Discussions**: Community Q&A and feature discussions
-- **🐛 Issues**: Bug reports and feature requests
+- **🐛 GitHub Issues**: Questions, bug reports, and feature requests
 - **🔒 Security**: Private security vulnerability reporting
 
 ### Contributing

--- a/packages/secretssync/SECURITY.md
+++ b/packages/secretssync/SECURITY.md
@@ -19,13 +19,15 @@ Instead, please report security vulnerabilities through one of the following met
 
 ### GitHub Security Advisories (Preferred)
 
-1. Go to the [Security Advisories](https://github.com/extended-data-library/secretssync/security/advisories) page
+1. Go to the [Security Advisories](https://github.com/jbcom/extended-data-library/security/advisories) page
 2. Click "Report a vulnerability"
 3. Fill out the form with details about the vulnerability
 
 ### Email (Alternative)
 
-If you cannot use GitHub Security Advisories, please open a confidential discussion at [GitHub Discussions](https://github.com/jbcom/go-secretsync/discussions) with the label "security".
+If you cannot use GitHub Security Advisories, email
+[`security@jbcom.dev`](mailto:security@jbcom.dev) with the details below. Do
+not open a public issue for security reports.
 
 Include the following information:
 - Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
@@ -126,7 +128,7 @@ We do not currently offer a formal bug bounty program, but we greatly appreciate
 For security-related questions or concerns:
 
 - **Security Issues**: Use GitHub Security Advisories
-- **General Security Questions**: Create a GitHub Discussion
+- **General Security Questions**: Email security@jbcom.dev
 - **Documentation Issues**: Create a regular GitHub Issue
 
 Thank you for helping keep SecretSync and our users safe!

--- a/packages/secretssync/docs/ACTION_QUICK_REFERENCE.md
+++ b/packages/secretssync/docs/ACTION_QUICK_REFERENCE.md
@@ -3,14 +3,14 @@
 ## Installation
 
 ```yaml
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
 ```
 
 ## Minimal Example
 
 ```yaml
 - name: Sync Secrets
-  uses: extended-data-library/secretssync@v1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
   env:
@@ -39,7 +39,7 @@
 ### Dry Run (PR Validation)
 
 ```yaml
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
     dry-run: 'true'
@@ -49,7 +49,7 @@
 ### Specific Targets
 
 ```yaml
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
     targets: 'Staging,Production'
@@ -58,7 +58,7 @@
 ### Merge Only
 
 ```yaml
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
     merge-only: 'true'
@@ -67,7 +67,7 @@
 ### With Exit Codes
 
 ```yaml
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
     dry-run: 'true'
@@ -78,7 +78,7 @@
 ### Debug Mode
 
 ```yaml
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
     log-level: 'debug'
@@ -112,7 +112,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
         env:
@@ -216,7 +216,7 @@ Use with `continue-on-error: true` to handle:
 ```yaml
 - name: Check Changes
   id: check
-  uses: extended-data-library/secretssync@v1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     dry-run: 'true'
     exit-code: 'true'
@@ -233,7 +233,7 @@ Use with `continue-on-error: true` to handle:
 
 ```yaml
 - uses: actions/checkout@v4  # Must checkout first!
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: path/to/config.yaml  # Relative to repo root
 ```
@@ -257,14 +257,11 @@ Ensure OIDC is configured correctly and trust policy allows your repository.
 ## Version Pinning
 
 ```yaml
-# Recommended: Pin to major version
-uses: extended-data-library/secretssync@v1
+# Recommended: Pin to a package release tag
+uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
 
-# More stable: Pin to specific version
-uses: extended-data-library/secretssync@v1.0.0
-
-# Not recommended: Latest from main
-uses: extended-data-library/secretssync@main
+# Not recommended: Track the branch tip
+uses: jbcom/extended-data-library/packages/secretssync@main
 ```
 
 ## License

--- a/packages/secretssync/docs/ERROR_CONTEXT.md
+++ b/packages/secretssync/docs/ERROR_CONTEXT.md
@@ -20,7 +20,7 @@ The request context is automatically generated at the pipeline start and propaga
 ```go
 import (
     "context"
-    reqctx "github.com/extended-data-library/secretssync/pkg/context"
+    reqctx "github.com/jbcom/extended-data-library/packages/secretssync/pkg/context"
 )
 
 // Generate request context
@@ -50,7 +50,7 @@ failed to list secrets: connection refused
 The `ErrorBuilder` provides a fluent API for constructing errors with context:
 
 ```go
-import reqctx "github.com/extended-data-library/secretssync/pkg/context"
+import reqctx "github.com/jbcom/extended-data-library/packages/secretssync/pkg/context"
 
 // Create error builder
 errBuilder := reqctx.NewErrorBuilder(ctx, "vault.write").

--- a/packages/secretssync/docs/FAQ.md
+++ b/packages/secretssync/docs/FAQ.md
@@ -39,17 +39,16 @@ Yes! SecretSync v1.2.0 is production-ready with:
 
 Multiple installation options:
 ```bash
-# Binary download
-curl -LO https://github.com/extended-data-library/secretssync/releases/latest/download/secretsync-linux-amd64
-
 # Go install
-go install github.com/extended-data-library/secretssync/cmd/secretsync@latest
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
 
 # Docker
-docker pull extended-data-library/secretssync:latest
+docker pull jbcom/secretssync:v1
 
-# Helm
-helm install secretsync oci://registry-1.docker.io/extended-data-library/secretssync
+# Build from source
+git clone https://github.com/jbcom/extended-data-library.git
+cd extended-data-library/packages/secretssync
+make build
 ```
 
 ### What permissions does SecretSync need?
@@ -232,7 +231,7 @@ Use the GitHub Action:
 
 ```yaml
 - name: Sync Secrets
-  uses: extended-data-library/secretssync@v1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
     dry-run: 'false'
@@ -424,7 +423,7 @@ secretsync pipeline --config config.yaml --dry-run --show-values
 
 ### How do I report security issues?
 
-Use [GitHub Security Advisories](https://github.com/extended-data-library/secretssync/security/advisories) to report security vulnerabilities privately.
+Use [GitHub Security Advisories](https://github.com/jbcom/extended-data-library/security/advisories) to report security vulnerabilities privately.
 
 ## Development
 
@@ -466,15 +465,14 @@ go test -race ./...
 
 ### Where can I get help?
 
-- **Documentation**: [docs/](https://github.com/extended-data-library/secretssync/tree/main/docs)
-- **GitHub Issues**: For bugs and feature requests
-- **GitHub Discussions**: For questions and community support
-- **Examples**: [examples/](https://github.com/extended-data-library/secretssync/tree/main/examples)
+- **Documentation**: [docs/](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync/docs)
+- **GitHub Issues**: For bugs, questions, and feature requests
+- **Examples**: [examples/](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync/examples)
 
 ### How do I request a feature?
 
-1. Check existing [issues](https://github.com/extended-data-library/secretssync/issues) and [discussions](https://github.com/extended-data-library/secretssync/discussions)
-2. Create a [feature request](https://github.com/extended-data-library/secretssync/issues/new/choose)
+1. Check existing [issues](https://github.com/jbcom/extended-data-library/issues)
+2. Create a [feature request](https://github.com/jbcom/extended-data-library/issues/new/choose)
 3. Provide detailed use case and requirements
 
 ### Is there a roadmap?
@@ -483,4 +481,4 @@ See [ROADMAP.md](./ROADMAP.md) for planned features and timeline.
 
 ---
 
-**Didn't find your question?** [Ask in GitHub Discussions](https://github.com/extended-data-library/secretssync/discussions) or [create an issue](https://github.com/extended-data-library/secretssync/issues/new/choose).
+**Didn't find your question?** [Open an issue](https://github.com/jbcom/extended-data-library/issues/new/choose).

--- a/packages/secretssync/docs/GETTING_STARTED.md
+++ b/packages/secretssync/docs/GETTING_STARTED.md
@@ -15,34 +15,29 @@ Before you begin, ensure you have:
 
 Choose your preferred installation method:
 
-### Option A: Download Binary
+### Option A: Go Install
 
 ```bash
-# Download latest release
-curl -LO https://github.com/extended-data-library/secretssync/releases/latest/download/secretsync-linux-amd64
-
-# Make executable and move to PATH
-chmod +x secretsync-linux-amd64
-sudo mv secretsync-linux-amd64 /usr/local/bin/secretsync
-
-# Verify installation
-secretsync version
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
 ```
 
-### Option B: Go Install
-
-```bash
-go install github.com/extended-data-library/secretssync/cmd/secretsync@latest
-```
-
-### Option C: Docker
+### Option B: Docker
 
 ```bash
 # Pull image
-docker pull extended-data-library/secretssync:latest
+docker pull jbcom/secretssync:v1
 
 # Create alias for easier usage
-alias secretsync='docker run --rm -v $(pwd):/workspace extended-data-library/secretssync'
+alias secretsync='docker run --rm -v "$PWD":/workspace -w /workspace jbcom/secretssync:v1'
+```
+
+### Option C: Build from Source
+
+```bash
+git clone https://github.com/jbcom/extended-data-library.git
+cd extended-data-library/packages/secretssync
+make build
+./bin/secretsync version
 ```
 
 ## Step 2: Basic Configuration
@@ -229,7 +224,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
         env:
@@ -346,10 +341,9 @@ aws secretsmanager list-secrets --region us-east-1
 
 ## Getting Help
 
-- **Documentation**: [Full docs](https://github.com/extended-data-library/secretssync/tree/main/docs)
-- **Examples**: [Configuration examples](https://github.com/extended-data-library/secretssync/tree/main/examples)
-- **Issues**: [GitHub Issues](https://github.com/extended-data-library/secretssync/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/extended-data-library/secretssync/discussions)
+- **Documentation**: [Full docs](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync/docs)
+- **Examples**: [Configuration examples](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync/examples)
+- **Issues**: [GitHub Issues](https://github.com/jbcom/extended-data-library/issues)
 
 ## What's Next?
 

--- a/packages/secretssync/docs/GITHUB_ACTIONS.md
+++ b/packages/secretssync/docs/GITHUB_ACTIONS.md
@@ -30,7 +30,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
 ```
@@ -86,7 +86,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Validate Changes (Dry Run)
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
           dry-run: 'true'
@@ -133,7 +133,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
           targets: ${{ github.event.inputs.targets != 'all' && github.event.inputs.targets || '' }}
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Merge Secrets
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
           merge-only: 'true'
@@ -200,7 +200,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync with Discovery
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
           discover: 'true'
@@ -241,7 +241,7 @@ jobs:
       
       - name: Check for Changes
         id: check
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
           dry-run: 'true'
@@ -254,7 +254,7 @@ jobs:
       
       - name: Apply Changes
         if: steps.check.outcome == 'failure'
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
           output-format: 'github'
@@ -300,7 +300,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: configs/${{ github.event.inputs.environment }}.yaml
           output-format: 'github'
@@ -392,7 +392,7 @@ jobs:
   sync-production:
     environment: production  # Requires approval
     steps:
-      - uses: extended-data-library/secretssync@v1
+      - uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: production.yaml
 ```
@@ -514,7 +514,7 @@ Ensure your config file is in the repository and the path is correct:
 ```yaml
 - uses: actions/checkout@v4  # Required to access repository files
 
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: path/to/config.yaml  # Relative to repo root
 ```
@@ -524,7 +524,7 @@ Ensure your config file is in the repository and the path is correct:
 Verify environment variables are set correctly:
 
 ```yaml
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
     log-level: debug  # Enable debug logging
@@ -546,7 +546,7 @@ Check:
 Ensure `output-format` is set to `github`:
 
 ```yaml
-- uses: extended-data-library/secretssync@v1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     output-format: 'github'  # Enables GitHub Actions annotations
 ```
@@ -566,7 +566,7 @@ Example using exit codes:
 ```yaml
 - name: Check for Changes
   id: check
-  uses: extended-data-library/secretssync@v1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     dry-run: 'true'
     exit-code: 'true'
@@ -608,7 +608,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: extended-data-library/secretssync@v1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: configs/${{ matrix.environment }}.yaml
 ```
@@ -628,7 +628,7 @@ jobs:
   sync:
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: extended-data-library/secretssync@v1
+      - uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
 ```
 
 ### Composite Actions
@@ -651,7 +651,7 @@ runs:
         role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
         aws-region: us-east-1
     
-    - uses: extended-data-library/secretssync@v1
+    - uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
       with:
         config: ${{ inputs.config }}
         output-format: 'github'
@@ -662,10 +662,9 @@ runs:
 
 ## Support
 
-- **Documentation**: [Full docs](https://github.com/extended-data-library/secretssync/tree/main/docs)
-- **Issues**: [GitHub Issues](https://github.com/extended-data-library/secretssync/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/extended-data-library/secretssync/discussions)
+- **Documentation**: [Full docs](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync/docs)
+- **Issues**: [GitHub Issues](https://github.com/jbcom/extended-data-library/issues)
 
 ## License
 
-MIT License - see [LICENSE](https://github.com/extended-data-library/secretssync/blob/main/LICENSE)
+MIT License - see [LICENSE](https://github.com/jbcom/extended-data-library/blob/main/packages/secretssync/LICENSE)

--- a/packages/secretssync/docs/MARKETPLACE.md
+++ b/packages/secretssync/docs/MARKETPLACE.md
@@ -72,7 +72,7 @@ SecretSync provides fully automated, real-time secret synchronization between Ha
 - [x] **Clear naming**: Descriptive and searchable name
 - [x] **Useful description**: Clear value proposition
 - [x] **Good documentation**: Step-by-step guides and examples
-- [x] **Community support**: GitHub Issues and Discussions
+- [x] **Community support**: GitHub Issues
 - [x] **Regular updates**: Active maintenance and improvements
 
 ## Publishing to Marketplace
@@ -241,20 +241,20 @@ Add these to README for visibility:
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[![GitHub release](https://img.shields.io/github/release/extended-data-library/secretssync.svg)](https://github.com/extended-data-library/secretssync/releases)
+[![GitHub release](https://img.shields.io/github/v/release/jbcom/extended-data-library?filter=secretssync-v*&label=release)](https://github.com/jbcom/extended-data-library/releases)
 
-[![GitHub stars](https://img.shields.io/github/stars/extended-data-library/secretssync.svg)](https://github.com/extended-data-library/secretssync/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/jbcom/extended-data-library.svg)](https://github.com/jbcom/extended-data-library/stargazers)
 ```
 
 ## Support URLs
 
 Add these to the Marketplace listing:
 
-- **Documentation**: https://github.com/extended-data-library/secretssync/tree/main/docs
-- **Issues**: https://github.com/extended-data-library/secretssync/issues
-- **Support**: https://github.com/extended-data-library/secretssync/blob/main/docs/SUPPORT.md
-- **Privacy Policy**: https://github.com/extended-data-library/secretssync/blob/main/docs/PRIVACY.md
-- **Security**: https://github.com/extended-data-library/secretssync/blob/main/docs/SECURITY.md
+- **Documentation**: https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync/docs
+- **Issues**: https://github.com/jbcom/extended-data-library/issues
+- **Support**: https://github.com/jbcom/extended-data-library/blob/main/packages/secretssync/docs/SUPPORT.md
+- **Privacy Policy**: https://github.com/jbcom/extended-data-library/blob/main/packages/secretssync/docs/PRIVACY.md
+- **Security**: https://github.com/jbcom/extended-data-library/blob/main/packages/secretssync/docs/SECURITY.md
 
 ## Verification Requirements
 
@@ -281,7 +281,7 @@ For verified publisher status:
 Track these metrics:
 - Daily/monthly active users
 - Total installations
-- Popular use cases (from issues/discussions)
+- Popular use cases (from issues and support requests)
 - User feedback and ratings
 - Common problems/questions
 
@@ -311,7 +311,7 @@ See [Security Policy](./SECURITY.md) for details.
 ### Support
 
 - GitHub Issues for bug reports
-- GitHub Discussions for Q&A
+- GitHub Issues for Q&A
 - Email for security issues
 - Community-driven support
 

--- a/packages/secretssync/docs/OBSERVABILITY.md
+++ b/packages/secretssync/docs/OBSERVABILITY.md
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: secretsync
-        image: extended-data-library/secretssync:latest
+        image: jbcom/secretssync:v1
         args:
           - pipeline
           - --config

--- a/packages/secretssync/docs/PIPELINE.md
+++ b/packages/secretssync/docs/PIPELINE.md
@@ -359,20 +359,16 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
       
-      - name: Install secretsync
-        run: |
-          curl -sL https://github.com/extended-data-library/secretssync/releases/latest/download/secretsync_linux_amd64 \
-            -o /usr/local/bin/secretsync && chmod +x /usr/local/bin/secretsync
-      
       - name: Run Pipeline
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        with:
+          config: config.yaml
+          targets: ${{ inputs.targets || '' }}
+          dry-run: ${{ inputs.dry_run || false }}
+          output-format: github
         env:
           VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
           VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
-        run: |
-          secretsync pipeline \
-            --config config.yaml \
-            --targets "${{ inputs.targets || 'all' }}" \
-            ${{ inputs.dry_run && '--dry-run' || '' }}
 ```
 
 ### GitLab CI
@@ -380,12 +376,11 @@ jobs:
 ```yaml
 secrets-sync:
   stage: deploy
-  image: alpine
+  image: golang:1.25
   before_script:
-    - wget -O /usr/local/bin/secretsync https://github.com/extended-data-library/secretssync/releases/latest/download/secretsync_linux_amd64
-    - chmod +x /usr/local/bin/secretsync
+    - go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
   script:
-    - secretsync pipeline --config config.yaml
+    - /go/bin/secretsync pipeline --config config.yaml
   only:
     - schedules
     - web

--- a/packages/secretssync/docs/PRIVACY.md
+++ b/packages/secretssync/docs/PRIVACY.md
@@ -98,7 +98,7 @@ Since SecretSync doesn't collect any personal data:
 ### Open Source
 
 SecretSync is fully open source:
-- **Source Code**: Available at [github.com/extended-data-library/secretssync](https://github.com/extended-data-library/secretssync)
+- **Source Code**: Available in the [SecretSync package directory](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync)
 - **Transparency**: All code is reviewable
 - **Community**: Issues and improvements are publicly tracked
 
@@ -112,7 +112,7 @@ All SecretSync operations are logged in your GitHub Actions logs, which you cont
 ## Changes to This Policy
 
 We may update this privacy policy from time to time. Changes will be:
-- Posted to the [SecretSync repository](https://github.com/extended-data-library/secretssync)
+- Posted to the [SecretSync repository](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync)
 - Documented in the CHANGELOG
 - Effective immediately upon posting
 
@@ -121,8 +121,8 @@ We may update this privacy policy from time to time. Changes will be:
 For privacy-related questions or concerns:
 
 - **Email**: [Contact via GitHub](https://github.com/jbcom)
-- **Issues**: [GitHub Issues](https://github.com/extended-data-library/secretssync/issues)
-- **Security**: See [SECURITY.md](https://github.com/extended-data-library/secretssync/blob/main/docs/SECURITY.md)
+- **Issues**: [GitHub Issues](https://github.com/jbcom/extended-data-library/issues)
+- **Security**: See [SECURITY.md](https://github.com/jbcom/extended-data-library/blob/main/packages/secretssync/docs/SECURITY.md)
 
 ## Compliance
 
@@ -144,7 +144,7 @@ Organizations using SecretSync for compliance:
 
 ## License
 
-SecretSync is licensed under the [MIT License](https://github.com/extended-data-library/secretssync/blob/main/LICENSE).
+SecretSync is licensed under the [MIT License](https://github.com/jbcom/extended-data-library/blob/main/packages/secretssync/LICENSE).
 
 ---
 

--- a/packages/secretssync/docs/PUBLISHING_CHECKLIST.md
+++ b/packages/secretssync/docs/PUBLISHING_CHECKLIST.md
@@ -111,7 +111,7 @@ git push origin v1 --force
 
 ### Step 3: Create GitHub Release
 
-1. Go to: https://github.com/extended-data-library/secretssync/releases
+1. Go to: https://github.com/jbcom/extended-data-library/releases
 2. Click "Draft a new release"
 3. Select tag: `v1.0.0`
 4. Release title: `v1.0.0 - GitHub Marketplace Release`
@@ -137,7 +137,7 @@ SecretSync is now available as a GitHub Action! This release provides a Docker-b
 
 ```yaml
 - name: Sync Secrets
-  uses: extended-data-library/secretssync@v1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
   with:
     config: config.yaml
   env:
@@ -197,7 +197,7 @@ MIT License - See [LICENSE](./LICENSE)
    ```
 
 2. **Announce release**
-   - Create GitHub Discussion
+   - Open a tracking issue for launch feedback
    - Tweet/share on social media
    - Update any external documentation
 
@@ -207,7 +207,7 @@ MIT License - See [LICENSE](./LICENSE)
    - Track usage metrics (if available)
 
 4. **Set up monitoring**
-   - Enable GitHub Discussions
+   - Confirm issue templates and labels are ready
    - Set up issue templates
    - Configure automated responses
 
@@ -267,7 +267,7 @@ To update marketplace listing:
 After publishing, provide support through:
 
 1. **GitHub Issues**: Bug reports and feature requests
-2. **GitHub Discussions**: Questions and community support
+2. **GitHub Issues**: Questions and community support
 3. **Email**: Security issues (private reporting)
 4. **Documentation**: Keep docs updated with common questions
 

--- a/packages/secretssync/docs/PYTHON_BINDINGS.md
+++ b/packages/secretssync/docs/PYTHON_BINDINGS.md
@@ -38,8 +38,8 @@ go install golang.org/x/tools/cmd/goimports@latest
 go install github.com/go-python/gopy@latest
 
 # Clone and build
-git clone https://github.com/extended-data-library/secretssync.git
-cd secretssync
+git clone https://github.com/jbcom/extended-data-library.git
+cd extended-data-library/packages/secretssync
 make python-bindings
 make python-install
 ```
@@ -49,7 +49,7 @@ make python-install
 If you have the `secretsync` CLI installed, the Python connector will use it automatically:
 
 ```bash
-go install github.com/extended-data-library/secretssync/cmd/secretsync@latest
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
 pip install vendor-connectors[secrets]
 ```
 

--- a/packages/secretssync/docs/ROADMAP.md
+++ b/packages/secretssync/docs/ROADMAP.md
@@ -126,7 +126,7 @@ Based on community feedback, we're prioritizing:
 ## How to Influence the Roadmap
 
 ### 🗳️ Community Input
-- **GitHub Discussions**: Share your use cases and requirements
+- **GitHub Issues**: Share your use cases and requirements
 - **Feature Requests**: Create detailed feature requests with business justification
 - **User Surveys**: Participate in periodic user surveys
 - **Community Calls**: Join monthly community calls (coming in v1.3.0)
@@ -209,8 +209,8 @@ Based on community feedback, we're prioritizing:
 
 ## Questions?
 
-- **Roadmap Discussions**: [GitHub Discussions](https://github.com/extended-data-library/secretssync/discussions)
-- **Feature Requests**: [GitHub Issues](https://github.com/extended-data-library/secretssync/issues)
+- **Roadmap Feedback**: [GitHub Issues](https://github.com/jbcom/extended-data-library/issues)
+- **Feature Requests**: [GitHub Issues](https://github.com/jbcom/extended-data-library/issues)
 - **Enterprise Inquiries**: Contact us through GitHub Issues
 - **Community**: Join our growing community of users and contributors
 

--- a/packages/secretssync/docs/SUPPORT.md
+++ b/packages/secretssync/docs/SUPPORT.md
@@ -17,24 +17,11 @@ Start with our comprehensive documentation:
 
 ## 💬 Community Support
 
-### GitHub Discussions
-
-For questions, ideas, and community discussion:
-
-**[GitHub Discussions](https://github.com/extended-data-library/secretssync/discussions)**
-
-Best for:
-- How-to questions
-- Architecture discussions
-- Feature ideas
-- Sharing your use cases
-- General Q&A
-
 ### GitHub Issues
 
-For bug reports and feature requests:
+Use repo issues for bug reports, feature ideas, and how-to questions:
 
-**[GitHub Issues](https://github.com/extended-data-library/secretssync/issues)**
+**[GitHub Issues](https://github.com/jbcom/extended-data-library/issues)**
 
 Before opening an issue:
 1. Search existing issues to avoid duplicates
@@ -75,12 +62,12 @@ What actually happens
 ### How to Report Security Issues
 
 1. **GitHub Security Advisories** (Recommended)
-   - Go to: https://github.com/extended-data-library/secretssync/security/advisories
+   - Go to: https://github.com/jbcom/extended-data-library/security/advisories
    - Click "Report a vulnerability"
    - Provide details privately
 
 2. **Email** (Alternative)
-   - Contact: security@jbcom.dev (if available) or create a private security advisory
+   - Contact: security@jbcom.dev
 
 3. **Response Time**
    - We aim to respond within 48 hours
@@ -106,7 +93,7 @@ When reporting bugs, please include:
    
    # If using GitHub Action
    # Include the version/tag from your workflow
-   uses: extended-data-library/secretssync@v1
+   uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
    ```
 
 2. **Configuration** (sanitized - remove secrets!)
@@ -129,7 +116,7 @@ When reporting bugs, please include:
 
 We welcome feature requests! When requesting a feature:
 
-1. **Check Existing Requests**: Search issues and discussions first
+1. **Check Existing Requests**: Search existing issues first
 2. **Describe the Use Case**: Why is this feature needed?
 3. **Propose a Solution**: How should it work?
 4. **Consider Alternatives**: What workarounds exist today?
@@ -245,22 +232,19 @@ Yes! SecretSync is production-ready. Many organizations use it daily.
 For GitHub Actions:
 ```yaml
 # Pin to major version (recommended)
-uses: extended-data-library/secretssync@v1
+uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
 
 # Pin to specific version (most stable)
-uses: extended-data-library/secretssync@v1.2.3
+uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
 
 # Use latest (not recommended for production)
-uses: extended-data-library/secretssync@main
+uses: jbcom/extended-data-library/packages/secretssync@main
 ```
 
 For CLI:
 ```bash
-# Download latest release
-curl -LO https://github.com/extended-data-library/secretssync/releases/latest/download/secretsync-linux-amd64
-
-# Or use go install
-go install github.com/extended-data-library/secretssync/cmd/secretsync@latest
+# Use go install
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
 ```
 
 ### Where do I report a security issue?
@@ -269,7 +253,7 @@ See our [Security Policy](./SECURITY.md) and contact us privately.
 
 ### How can I contribute?
 
-See the Contributing section above or open a discussion!
+See the Contributing section above or open an issue.
 
 ## 📝 Feedback
 
@@ -283,10 +267,9 @@ Your feedback helps us improve! Please:
 
 ## 🔗 Links
 
-- **Repository**: [github.com/extended-data-library/secretssync](https://github.com/extended-data-library/secretssync)
-- **Issues**: [github.com/extended-data-library/secretssync/issues](https://github.com/extended-data-library/secretssync/issues)
-- **Discussions**: [github.com/extended-data-library/secretssync/discussions](https://github.com/extended-data-library/secretssync/discussions)
-- **Releases**: [github.com/extended-data-library/secretssync/releases](https://github.com/extended-data-library/secretssync/releases)
+- **Repository**: [SecretSync package](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync)
+- **Issues**: [GitHub Issues](https://github.com/jbcom/extended-data-library/issues)
+- **Releases**: [Release list](https://github.com/jbcom/extended-data-library/releases)
 - **License**: [MIT License](../LICENSE)
 
 ---

--- a/packages/secretssync/docs/development/contributing.md
+++ b/packages/secretssync/docs/development/contributing.md
@@ -1,64 +1,58 @@
 # Contributing
 
-Thank you for your interest in contributing to PACKAGE_NAME!
+Thank you for your interest in contributing to SecretSync.
 
 ## Development Setup
 
 ```bash
-# Clone the repository
-git clone https://github.com/jbcom/PACKAGE_NAME.git
-cd PACKAGE_NAME
+git clone https://github.com/jbcom/extended-data-library.git
+cd extended-data-library/packages/secretssync
 
-# Install with all development dependencies
-uv sync --all-extras
+# Download Go dependencies
+go mod download
 ```
 
 ## Running Tests
 
 ```bash
-# Run tests
-uv run pytest
+# Unit tests
+go test ./...
 
-# Run with coverage
-uv run pytest --cov=PACKAGE_NAME
+# Race-enabled unit tests with coverage output
+make test
+
+# Integration tests (starts local test services via docker-compose)
+make test-integration-docker
 ```
 
 ## Code Style
 
 This project uses:
-- [Ruff](https://docs.astral.sh/ruff/) for linting and formatting
-- Type hints throughout
+- `gofmt` for formatting
+- `golangci-lint` for linting
+- GoDoc comments for exported APIs
 
 ```bash
-# Check code style
-uv run ruff check .
-uv run ruff format --check .
-
-# Auto-fix issues
-uv run ruff check --fix .
-uv run ruff format .
+gofmt ./...
+golangci-lint run
 ```
 
-## Building Documentation
+## Building and Bindings
 
 ```bash
-# Install docs dependencies
-uv sync --extra docs
+# Build the CLI
+make build
 
-# Build docs
-cd docs
-uv run sphinx-build -b html . _build/html
-
-# Or use make
-make html
+# Generate Python bindings
+make python-bindings
 ```
 
 ## Pull Request Process
 
 1. Create a feature branch from `main`
 2. Make your changes with tests
-3. Ensure CI passes (lint + tests)
-4. Submit PR - an AI agent will review and merge
+3. Ensure lint and tests pass locally
+4. Submit a PR against `jbcom/extended-data-library`
 
 ## Commit Messages
 

--- a/packages/secretssync/docs/getting-started/installation.md
+++ b/packages/secretssync/docs/getting-started/installation.md
@@ -2,32 +2,42 @@
 
 ## Requirements
 
-- Python 3.9+
-- [uv](https://docs.astral.sh/uv/) (recommended) or pip
+- Go 1.25+
+- Docker (optional, for containerized runs or the GitHub Action image)
 
-## Install from PyPI
+## Install the CLI
 
 ```bash
-# Using uv (recommended)
-uv add PACKAGE_NAME
-
-# Using pip
-pip install PACKAGE_NAME
+# Install the latest CLI from the monorepo module path
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
 ```
 
-## Install from Source
+## Run with Docker
 
 ```bash
-git clone https://github.com/jbcom/PACKAGE_NAME.git
-cd PACKAGE_NAME
-uv sync
+docker pull jbcom/secretssync:v1
+
+# Example alias for local CLI-style usage
+alias secretsync='docker run --rm -v "$PWD":/workspace -w /workspace jbcom/secretssync:v1'
 ```
 
-## Development Installation
+## Build from Source
 
 ```bash
-# Clone and install with dev dependencies
-git clone https://github.com/jbcom/PACKAGE_NAME.git
-cd PACKAGE_NAME
-uv sync --extra dev --extra docs
+git clone https://github.com/jbcom/extended-data-library.git
+cd extended-data-library/packages/secretssync
+make build
+
+# The compiled binary is written to ./bin/secretsync
+./bin/secretsync version
+```
+
+## GitHub Action
+
+Use the packaged action from the monorepo subdirectory and pin to a package tag:
+
+```yaml
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+  with:
+    config: config.yaml
 ```

--- a/packages/secretssync/docs/getting-started/quickstart.md
+++ b/packages/secretssync/docs/getting-started/quickstart.md
@@ -1,18 +1,58 @@
 # Quickstart
 
-This guide will help you get started with PACKAGE_NAME.
+This guide walks through a minimal SecretSync dry run using the Go CLI and one
+of the package example configs.
 
-## Basic Usage
+## 1. Install the CLI
 
-```python
-# TODO: Add basic usage example
-from PACKAGE_NAME import example
+```bash
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
+```
 
-result = example.do_something()
-print(result)
+## 2. Start from an example config
+
+```bash
+git clone https://github.com/jbcom/extended-data-library.git
+cd extended-data-library/packages/secretssync
+cp examples/pipeline-config.yaml pipeline.yaml
+```
+
+Edit `pipeline.yaml` for your Vault address, AWS role pattern, source paths,
+and targets.
+
+## 3. Export credentials
+
+```bash
+export VAULT_ADDR="https://vault.example.com"
+export VAULT_ROLE_ID="your-role-id"
+export VAULT_SECRET_ID="your-secret-id"
+export AWS_REGION="us-east-1"
+```
+
+If you are not using ambient AWS credentials or OIDC, also export
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+
+## 4. Validate before syncing
+
+```bash
+secretsync validate --config pipeline.yaml
+```
+
+## 5. Run a dry run
+
+```bash
+secretsync pipeline --config pipeline.yaml --dry-run --output compact
+```
+
+## 6. Apply the pipeline
+
+```bash
+secretsync pipeline --config pipeline.yaml
 ```
 
 ## Next Steps
 
-- Check out the [API Reference](../api/index.rst) for detailed documentation
-- See [Contributing](../development/contributing.md) to help improve this project
+- Read [../GETTING_STARTED.md](../GETTING_STARTED.md) for a longer walkthrough
+- Review [../PIPELINE.md](../PIPELINE.md) for config details and advanced flags
+- See [../development/contributing.md](../development/contributing.md) if you
+  want to work on the package

--- a/packages/secretssync/examples/github-action-workflow.yml
+++ b/packages/secretssync/examples/github-action-workflow.yml
@@ -3,8 +3,8 @@ name: Sync Secrets with SecretSync
 # This is a complete example workflow showing how to use SecretSync
 # as a GitHub Action for automated secrets synchronization.
 #
-# Note: After initial release, you can use @v1 to get automatic updates,
-# or pin to @v1.0.0 for stability. This example uses @v1.0.0 for initial release.
+# Pin to a package release tag for reproducible runs.
+# This example uses the latest current package tag.
 
 on:
   # Scheduled sync every 6 hours
@@ -67,7 +67,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Validate Configuration (Dry Run)
-        uses: extended-data-library/secretssync@v1.0.0  # Use specific version for first release
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: config.yaml
           dry-run: 'true'
@@ -107,7 +107,7 @@ jobs:
           role-session-name: GitHubActions-SecretSync-${{ github.run_id }}
       
       - name: Run SecretSync
-        uses: extended-data-library/secretssync@v1.0.0  # Use specific version for first release
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
         with:
           config: ${{ steps.config.outputs.config }}
           targets: ${{ github.event.inputs.targets || '' }}


### PR DESCRIPTION
## Summary
- replace stale standalone SecretSync repo references with the current monorepo module, package, and issue paths
- rewrite the placeholder SecretSync installation, quickstart, and contributing pages with package-accurate instructions
- align GitHub Action examples with the real subdirectory action ref and current package tag

## Validation
- git diff --check
- go test ./... (in packages/secretssync)