### PR TITLE
docs(connectors): align slack fallback version note

### DIFF
--- a/packages/vendor-connectors/src/vendor_connectors/slack/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/slack/__init__.py
@@ -16,7 +16,7 @@ else:
     from itertools import islice
 
     def batched(iterable, n: int) -> Iterator[tuple]:
-        """Batch an iterable into chunks of size n (Python 3.9+ compatible)."""
+        """Batch an iterable into chunks of size n for Python < 3.12."""
         it = iter(iterable)
         while batch := tuple(islice(it, n)):
             yield batch


### PR DESCRIPTION
## Summary
- align the Slack connector fallback `batched()` docstring with the actual compatibility boundary
- make the note match the package support policy (`>=3.10`) and Python stdlib behavior (`itertools.batched` added in 3.12)

## Testing
- tox -e lint