### PR TITLE
docs(repo): align issue and action guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📚 Documentation
-    url: https://github.com/jbcom
-    about: Check the docs before filing an issue
-  # TODO: Enable org discussions after migration to jbcom organization
-  # - name: 💬 Discussions
-  #   url: https://github.com/orgs/jbcom/discussions
-  #   about: Ask questions and discuss ideas
-  - name: 💬 Discussions
-    url: https://github.com/jbcom?tab=repositories
-    about: Find repository-specific discussions in each project (org discussions coming soon)
+    url: https://extendeddata.dev
+    about: Read the package guides, examples, and API docs before filing an issue
+  - name: 🛡️ Security Policy
+    url: https://github.com/jbcom/extended-data-library/security/policy
+    about: Report vulnerabilities privately instead of opening a public issue

--- a/packages/secretssync/action.yml
+++ b/packages/secretssync/action.yml
@@ -4,10 +4,12 @@ author: "jbcom"
 description: "Sync secrets from HashiCorp Vault to AWS Secrets Manager across multiple accounts"
 runs:
   using: "docker"
-  # TODO: Once release workflow automation exists, use immutable digest format:
-  # 1. Get digest: docker pull jbcom/secretssync:v1 && docker inspect --format='{{index .RepoDigests 0}}' jbcom/secretssync:v1
-  # 2. Update to: image: "docker://jbcom/secretssync:v1@sha256:<digest>"
-  # For now, using tag-based reference until digest automation is implemented
+  # Prefer a digest-pinned image once the release workflow can refresh the
+  # action reference automatically:
+  # 1. docker pull jbcom/secretssync:v1
+  # 2. docker inspect --format='{{index .RepoDigests 0}}' jbcom/secretssync:v1
+  # 3. image: "docker://jbcom/secretssync:v1@sha256:<digest>"
+  # Until then, keep the release-please-managed tag reference below.
   image: "docker://jbcom/secretssync:v1" # x-release-please-version
 branding:
   icon: "lock"


### PR DESCRIPTION
## Summary
- replace stale issue template contact links with the live docs site and security policy
- remove the placeholder discussions wording now that the repo does not use GitHub Discussions
- rewrite the SecretSync action image note as current guidance instead of a lingering TODO

## Testing
- `git diff --check`
- `python3` YAML parse for `.github/ISSUE_TEMPLATE/config.yml` and `packages/secretssync/action.yml`
