### PR TITLE
docs(repo): align package metadata and docs extras

### DIFF
--- a/packages/directed-inputs-class/README.md
+++ b/packages/directed-inputs-class/README.md
@@ -313,5 +313,5 @@ Contributions are welcome! Please see the [Contributing Guidelines](https://gith
 
 - [**PyPI**](https://pypi.org/project/directed-inputs-class/)
 - [**GitHub**](https://github.com/jbcom/extended-data-library/tree/main/packages/directed-inputs-class)
-- [**Documentation**](https://extendeddata.dev)
+- [**Documentation**](https://extendeddata.dev/packages/inputs/)
 - [**Changelog**](https://github.com/jbcom/extended-data-library/blob/main/packages/directed-inputs-class/CHANGELOG.md)

--- a/packages/directed-inputs-class/pyproject.toml
+++ b/packages/directed-inputs-class/pyproject.toml
@@ -30,10 +30,10 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://extendeddata.dev"
-Issues = "https://github.com/extended-data-library/extended-data-types/issues"
-Source = "https://github.com/extended-data-library/extended-data-types"
-Changelog = "https://github.com/extended-data-library/extended-data-types/blob/main/packages/directed-inputs-class/CHANGELOG.md"
+Documentation = "https://extendeddata.dev/packages/inputs/"
+Issues = "https://github.com/jbcom/extended-data-library/issues"
+Source = "https://github.com/jbcom/extended-data-library/tree/main/packages/directed-inputs-class"
+Changelog = "https://github.com/jbcom/extended-data-library/blob/main/packages/directed-inputs-class/CHANGELOG.md"
 
 [project.optional-dependencies]
 tests = [
@@ -50,12 +50,9 @@ typing = [
 ]
 docs = [
     "sphinx>=7.0",
-    "sphinx-rtd-theme>=2.0.0",
-    "sphinx-autodoc-typehints>=2.0.0",
-    "sphinxawesome-theme>=5.2.0",
-    "sphinx-autodoc2>=0.5.0",
     "myst-parser>=3.0.1",
-    "docutils>=0.17",
+    "sphinx-autodoc2>=0.5.0",
+    "sphinx-markdown-builder>=0.6.0",
 ]
 
 [tool.uv.sources]

--- a/packages/extended-data-types/pyproject.toml
+++ b/packages/extended-data-types/pyproject.toml
@@ -68,17 +68,16 @@ typing = [
 ]
 docs = [
     "sphinx>=7.0",
-    "sphinx-rtd-theme>=2.0.0",
-    "sphinx-autodoc-typehints>=2.0.0",
     "myst-parser>=3.0.1",
-    "docutils>=0.17",
+    "sphinx-autodoc2>=0.5.0",
+    "sphinx-markdown-builder>=0.6.0",
 ]
 
 [project.scripts]
 edt-mcp = "extended_data_types.mcp_server:main"
 
 [tool.hatch.build.targets.sdist]
-exclude = [".github", "/docs", "/memory-bank", "/tests", "/tox.ini"]
+exclude = [".github", "/docs", "/tests", "/tox.ini"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/extended_data_types"]

--- a/packages/lifecyclelogging/README.md
+++ b/packages/lifecyclelogging/README.md
@@ -114,5 +114,5 @@ Contributions are welcome! Please see the [Contributing Guidelines](https://gith
 
 - [**PyPI**](https://pypi.org/project/lifecyclelogging/)
 - [**GitHub**](https://github.com/jbcom/extended-data-library/tree/main/packages/lifecyclelogging)
-- [**Documentation**](https://extendeddata.dev)
+- [**Documentation**](https://extendeddata.dev/packages/logging/)
 - [**Changelog**](https://github.com/jbcom/extended-data-library/blob/main/packages/lifecyclelogging/CHANGELOG.md)

--- a/packages/lifecyclelogging/pyproject.toml
+++ b/packages/lifecyclelogging/pyproject.toml
@@ -30,10 +30,10 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://extendeddata.dev"
-Issues = "https://github.com/extended-data-library/extended-data-types/issues"
-Source = "https://github.com/extended-data-library/extended-data-types"
-Changelog = "https://github.com/extended-data-library/extended-data-types/blob/main/packages/lifecyclelogging/CHANGELOG.md"
+Documentation = "https://extendeddata.dev/packages/logging/"
+Issues = "https://github.com/jbcom/extended-data-library/issues"
+Source = "https://github.com/jbcom/extended-data-library/tree/main/packages/lifecyclelogging"
+Changelog = "https://github.com/jbcom/extended-data-library/blob/main/packages/lifecyclelogging/CHANGELOG.md"
 
 [project.optional-dependencies]
 tests = [
@@ -45,12 +45,9 @@ tests = [
 ]
 docs = [
     "sphinx>=7.4.0",
-    "sphinxawesome-theme>=5.2.0",
-    "sphinx-autodoc2>=0.5.0",
-    "sphinx-autodoc-typehints>=2.2.0",
-    "sphinx-rtd-theme>=2.0.0",
     "myst-parser>=3.0.1",
-    "docutils>=0.21.2",
+    "sphinx-autodoc2>=0.5.0",
+    "sphinx-markdown-builder>=0.6.0",
 ]
 typing = ["mypy>=1.10.1"]
 

--- a/packages/vendor-connectors/pyproject.toml
+++ b/packages/vendor-connectors/pyproject.toml
@@ -217,9 +217,9 @@ tests-e2e-all = [
 # === Documentation ===
 docs = [
     "sphinx>=8.1.3",
-    "sphinx-rtd-theme>=3.1.0",
-    "sphinx-autodoc-typehints>=3.0.1",
     "myst-parser>=4.0.1",
+    "sphinx-autodoc2>=0.5.0",
+    "sphinx-markdown-builder>=0.6.0",
 ]
 
 # === Development ===

--- a/uv.lock
+++ b/uv.lock
@@ -998,19 +998,13 @@ dependencies = [
 
 [package.optional-dependencies]
 docs = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx-autodoc-typehints", version = "3.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-autodoc2" },
-    { name = "sphinx-rtd-theme" },
-    { name = "sphinxawesome-theme" },
+    { name = "sphinx-markdown-builder" },
 ]
 tests = [
     { name = "coverage", extra = ["toml"] },
@@ -1030,7 +1024,6 @@ requires-dist = [
     { name = "case-insensitive-dictionary", specifier = ">=0.2.1" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'tests'", specifier = ">=7.6.0" },
     { name = "deepmerge", specifier = ">=1.1.1" },
-    { name = "docutils", marker = "extra == 'docs'", specifier = ">=0.17" },
     { name = "extended-data-types", editable = "packages/extended-data-types" },
     { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.0.0" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=3.0.1" },
@@ -1041,10 +1034,8 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sortedcontainers-stubs", marker = "extra == 'typing'", specifier = ">=2.4.2" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=2.0.0" },
     { name = "sphinx-autodoc2", marker = "extra == 'docs'", specifier = ">=0.5.0" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=2.0.0" },
-    { name = "sphinxawesome-theme", marker = "extra == 'docs'", specifier = ">=5.2.0" },
+    { name = "sphinx-markdown-builder", marker = "extra == 'docs'", specifier = ">=0.6.0" },
     { name = "types-pyyaml", marker = "extra == 'typing'", specifier = ">=6.0.12.20240724" },
 ]
 provides-extras = ["tests", "typing", "docs"]
@@ -1192,17 +1183,13 @@ dependencies = [
 
 [package.optional-dependencies]
 docs = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx-autodoc-typehints", version = "3.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-rtd-theme" },
+    { name = "sphinx-autodoc2" },
+    { name = "sphinx-markdown-builder" },
 ]
 mcp = [
     { name = "mcp" },
@@ -1228,7 +1215,6 @@ typing = [
 requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'tests'", specifier = ">=7.6.0" },
     { name = "deepmerge", specifier = ">=2.0" },
-    { name = "docutils", marker = "extra == 'docs'", specifier = ">=0.17" },
     { name = "gitpython", specifier = ">=3.1.0" },
     { name = "hypothesis", marker = "extra == 'tests'", specifier = ">=6.0.0" },
     { name = "inflection", specifier = ">=0.5.1" },
@@ -1250,8 +1236,8 @@ requires-dist = [
     { name = "sortedcontainers", specifier = ">=2.4.0" },
     { name = "sortedcontainers-stubs", marker = "extra == 'typing'", specifier = ">=2.4.2" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=2.0.0" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=2.0.0" },
+    { name = "sphinx-autodoc2", marker = "extra == 'docs'", specifier = ">=0.5.0" },
+    { name = "sphinx-markdown-builder", marker = "extra == 'docs'", specifier = ">=0.6.0" },
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "types-pyyaml", marker = "extra == 'typing'", specifier = ">=6.0.12.20240724" },
     { name = "validators", specifier = ">=0.22.0" },
@@ -2428,19 +2414,13 @@ dependencies = [
 
 [package.optional-dependencies]
 docs = [
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx-autodoc-typehints", version = "3.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-autodoc2" },
-    { name = "sphinx-rtd-theme" },
-    { name = "sphinxawesome-theme" },
+    { name = "sphinx-markdown-builder" },
 ]
 tests = [
     { name = "coverage", extra = ["toml"] },
@@ -2456,7 +2436,6 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'tests'", specifier = ">=7.6.0" },
-    { name = "docutils", marker = "extra == 'docs'", specifier = ">=0.21.2" },
     { name = "extended-data-types", editable = "packages/extended-data-types" },
     { name = "hypothesis", marker = "extra == 'tests'", specifier = ">=6.100.2" },
     { name = "mypy", marker = "extra == 'typing'", specifier = ">=1.10.1" },
@@ -2466,10 +2445,8 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'tests'", specifier = ">=3.6.1" },
     { name = "rich", specifier = ">=13.7.1" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.4.0" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=2.2.0" },
     { name = "sphinx-autodoc2", marker = "extra == 'docs'", specifier = ">=0.5.0" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=2.0.0" },
-    { name = "sphinxawesome-theme", marker = "extra == 'docs'", specifier = ">=5.2.0" },
+    { name = "sphinx-markdown-builder", marker = "extra == 'docs'", specifier = ">=0.6.0" },
 ]
 provides-extras = ["tests", "docs", "typing"]
 
@@ -5799,53 +5776,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/f0/43c6a5ff3e7b08a8c3b32f81b859f1b518ccc31e45f22e2b41ced38be7b9/sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55", size = 36282, upload-time = "2025-01-16T18:25:30.958Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/dc/dc46c5c7c566b7ec5e8f860f9c89533bf03c0e6aadc96fb9b337867e4460/sphinx_autodoc_typehints-3.0.1-py3-none-any.whl", hash = "sha256:4b64b676a14b5b79cefb6628a6dc8070e320d4963e8ff640a2f3e9390ae9045a", size = 20245, upload-time = "2025-01-16T18:25:27.394Z" },
-]
-
-[[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.6.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.11.*'",
-]
-dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/6a/c0360b115c81d449b3b73bf74b64ca773464d5c7b1b77bda87c5e874853b/sphinx_autodoc_typehints-3.6.1-py3-none-any.whl", hash = "sha256:dd818ba31d4c97f219a8c0fcacef280424f84a3589cedcb73003ad99c7da41ca", size = 20869, upload-time = "2026-01-02T15:23:45.194Z" },
-]
-
-[[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.7.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-]
-dependencies = [
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/54/319628e24e98102e6f73cf6e5f345324a94d9adc18d456193b84f2ac1608/sphinx_autodoc_typehints-3.7.0.tar.gz", hash = "sha256:f7c536f4c0a729324cfebfaa3787c80ca14d08817952153e6da4e971c5306c20", size = 41344, upload-time = "2026-02-23T20:54:58.529Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/2c/ded433effc5943195a64e18404fd46c195aca559cd9bede1ae73f8bbf67f/sphinx_autodoc_typehints-3.7.0-py3-none-any.whl", hash = "sha256:ad0c9759bac0c7462768003bb57e7bb853c75b74d603e818511c56c10931e72f", size = 21558, upload-time = "2026-02-23T20:54:57.015Z" },
-]
-
-[[package]]
 name = "sphinx-autodoc2"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5860,8 +5790,8 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-rtd-theme"
-version = "3.1.0"
+name = "sphinx-markdown-builder"
+version = "0.6.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -5869,26 +5799,11 @@ dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jquery" },
+    { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/68/a1bfbf38c0f7bccc9b10bbf76b94606f64acb1552ae394f0b8285bfaea25/sphinx_rtd_theme-3.1.0.tar.gz", hash = "sha256:b44276f2c276e909239a4f6c955aa667aaafeb78597923b1c60babc76db78e4c", size = 7620915, upload-time = "2026-01-12T16:03:31.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b3705885d51932e8b62f520388c2772e4952189971727b/sphinx_markdown_builder-0.6.10.tar.gz", hash = "sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86", size = 22688, upload-time = "2026-03-11T10:56:57.639Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/c7/b5c8015d823bfda1a346adb2c634a2101d50bb75d421eb6dcb31acd25ebc/sphinx_rtd_theme-3.1.0-py2.py3-none-any.whl", hash = "sha256:1785824ae8e6632060490f67cf3a72d404a85d2d9fc26bce3619944de5682b89", size = 7655617, upload-time = "2026-01-12T16:03:28.101Z" },
-]
-
-[[package]]
-name = "sphinxawesome-theme"
-version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/0e/6b8fc5e645c995c669c6895127703993f76dce2417018c09b2c6e92591dd/sphinxawesome_theme-6.0.0.tar.gz", hash = "sha256:b76e41fc56fcbf6691172530e61bcf352623eb3298114ba3e323fec5d792e07b", size = 342940, upload-time = "2026-01-22T07:01:56.482Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/ae/d28dfaa91e0baebccff073b45792a84eccd0c2572424423f033882c433e9/sphinxawesome_theme-6.0.0-py3-none-any.whl", hash = "sha256:aa076bafdd10f215bce2d586a77f765c2bf08992468cdaa28dc24815b847b291", size = 376107, upload-time = "2026-01-22T07:01:55.04Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
 ]
 
 [[package]]
@@ -5916,20 +5831,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-jquery"
-version = "4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/f3/aa67467e051df70a6330fe7770894b3e4f09436dea6881ae0b4f3d87cad8/sphinxcontrib-jquery-4.1.tar.gz", hash = "sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a", size = 122331, upload-time = "2023-03-14T15:01:01.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl", hash = "sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae", size = 121104, upload-time = "2023-03-14T15:01:00.356Z" },
 ]
 
 [[package]]
@@ -6030,6 +5931,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]
@@ -6525,7 +6435,7 @@ wheels = [
 
 [[package]]
 name = "vendor-connectors"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "packages/vendor-connectors" }
 dependencies = [
     { name = "deepmerge" },
@@ -6601,10 +6511,8 @@ docs = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx-autodoc-typehints", version = "3.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sphinx-rtd-theme" },
+    { name = "sphinx-autodoc2" },
+    { name = "sphinx-markdown-builder" },
 ]
 github = [
     { name = "pygithub" },
@@ -6824,8 +6732,8 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'all'", specifier = ">=3.41.0" },
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.41.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1.3" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=3.0.1" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=3.1.0" },
+    { name = "sphinx-autodoc2", marker = "extra == 'docs'", specifier = ">=0.5.0" },
+    { name = "sphinx-markdown-builder", marker = "extra == 'docs'", specifier = ">=0.6.0" },
     { name = "sqlite-vec", marker = "extra == 'all'", specifier = ">=0.1.9" },
     { name = "sqlite-vec", marker = "extra == 'vector'", specifier = ">=0.1.9" },
     { name = "strands-agents", marker = "extra == 'ai'", specifier = ">=1.35.0" },


### PR DESCRIPTION
## Summary
- fix stale package metadata URLs so package pages point at the monorepo and the correct docs pages
- align package `docs` extras with the current Sphinx-to-Astro builder stack instead of old theme-era dependencies
- remove the dead `/memory-bank` sdist exclude from `extended-data-types`

## Testing
- `uv lock`
- `uv build --package extended-data-types`
- `uv build --package lifecyclelogging`
- `uv build --package directed-inputs-class`
- `uv build --package vendor-connectors`
- `git diff --check`
