### PR TITLE
docs(site): align package CI badge links

### DIFF
--- a/docs/src/content/docs/core/data-types.mdx
+++ b/docs/src/content/docs/core/data-types.mdx
@@ -15,7 +15,7 @@ pip install extended-data-types
 
 [![PyPI](https://img.shields.io/pypi/v/extended-data-types.svg)](https://pypi.org/project/extended-data-types/)
 [![Python](https://img.shields.io/pypi/pyversions/extended-data-types.svg)](https://pypi.org/project/extended-data-types/)
-[![CI](https://github.com/jbcom/extended-data-library/workflows/CI/badge.svg)](https://github.com/jbcom/extended-data-library/actions)
+[![CI](https://github.com/jbcom/extended-data-library/actions/workflows/ci.yml/badge.svg)](https://github.com/jbcom/extended-data-library/actions/workflows/ci.yml)
 
 ---
 

--- a/docs/src/content/docs/packages/inputs.mdx
+++ b/docs/src/content/docs/packages/inputs.mdx
@@ -13,7 +13,7 @@ pip install directed-inputs-class
 
 [![PyPI](https://img.shields.io/pypi/v/directed-inputs-class.svg)](https://pypi.org/project/directed-inputs-class/)
 [![Python](https://img.shields.io/pypi/pyversions/directed-inputs-class.svg)](https://pypi.org/project/directed-inputs-class/)
-[![CI](https://github.com/jbcom/extended-data-library/workflows/CI/badge.svg)](https://github.com/jbcom/extended-data-library/actions)
+[![CI](https://github.com/jbcom/extended-data-library/actions/workflows/ci.yml/badge.svg)](https://github.com/jbcom/extended-data-library/actions/workflows/ci.yml)
 
 ---
 

--- a/docs/src/content/docs/packages/logging.mdx
+++ b/docs/src/content/docs/packages/logging.mdx
@@ -13,7 +13,7 @@ pip install lifecyclelogging
 
 [![PyPI](https://img.shields.io/pypi/v/lifecyclelogging.svg)](https://pypi.org/project/lifecyclelogging/)
 [![Python](https://img.shields.io/pypi/pyversions/lifecyclelogging.svg)](https://pypi.org/project/lifecyclelogging/)
-[![CI](https://github.com/jbcom/extended-data-library/workflows/CI/badge.svg)](https://github.com/jbcom/extended-data-library/actions)
+[![CI](https://github.com/jbcom/extended-data-library/actions/workflows/ci.yml/badge.svg)](https://github.com/jbcom/extended-data-library/actions/workflows/ci.yml)
 
 ---
 

--- a/docs/src/content/docs/packages/vendor-connectors.mdx
+++ b/docs/src/content/docs/packages/vendor-connectors.mdx
@@ -9,7 +9,7 @@ import { Tabs, TabItem, Aside, Card, CardGrid } from '@astrojs/starlight/compone
 
 [![PyPI](https://img.shields.io/pypi/v/vendor-connectors.svg)](https://pypi.org/project/vendor-connectors/)
 [![Python](https://img.shields.io/pypi/pyversions/vendor-connectors.svg)](https://pypi.org/project/vendor-connectors/)
-[![CI](https://github.com/jbcom/extended-data-library/workflows/CI/badge.svg)](https://github.com/jbcom/extended-data-library/actions)
+[![CI](https://github.com/jbcom/extended-data-library/actions/workflows/ci.yml/badge.svg)](https://github.com/jbcom/extended-data-library/actions/workflows/ci.yml)
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the old generic GitHub Actions badge URLs on the package landing pages
- point each docs-site package page at the canonical `ci.yml` badge and workflow URL used elsewhere in the repo

## Testing
- `git diff --check`
- `cd docs && npm run build`
