### PR TITLE
docs(site): add secretssync package page

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -89,7 +89,8 @@ export default defineConfig({
         {
           label: 'SecretSync',
           items: [
-            { label: 'Overview', slug: 'api/secretsync' },
+            { label: 'Overview', slug: 'packages/secretssync' },
+            { label: 'Legacy Overview Route', slug: 'api/secretsync' },
           ],
         },
         {

--- a/docs/src/content/docs/api/secretsync.mdx
+++ b/docs/src/content/docs/api/secretsync.mdx
@@ -3,6 +3,10 @@ title: SecretSync
 description: Vault-to-cloud secret synchronization tool written in Go
 ---
 
+> SecretSync now has a first-class package overview at
+> [packages/secretssync](/packages/secretssync/). Use this page as the
+> compatibility route for older links.
+
 **SecretSync** (`secretssync`) is a Go binary that synchronizes secrets from HashiCorp Vault to cloud provider secret stores (AWS Secrets Manager, GCP Secret Manager).
 
 ## Installation

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -60,6 +60,14 @@ Every Python project reinvents the same infrastructure: YAML parsing, environmen
     pip install vendor-connectors
     ```
   </Card>
+
+  <Card title="SecretSync" icon="seti:go">
+    A Go-based secret synchronization pipeline for Vault-to-cloud workflows, dry-run diffs, GitHub Actions, and multi-account automation.
+
+    ```bash
+    go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
+    ```
+  </Card>
 </CardGrid>
 
 ---
@@ -185,7 +193,7 @@ Or install individually — each package works on its own.
 | [directed-inputs-class](https://pypi.org/project/directed-inputs-class/) | ![PyPI](https://img.shields.io/pypi/v/directed-inputs-class.svg) | 3.10+ |
 | [lifecyclelogging](https://pypi.org/project/lifecyclelogging/) | ![PyPI](https://img.shields.io/pypi/v/lifecyclelogging.svg) | 3.10+ |
 | [vendor-connectors](https://pypi.org/project/vendor-connectors/) | ![PyPI](https://img.shields.io/pypi/v/vendor-connectors.svg) | 3.10+ |
-| [secretssync](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync) | Go binary | Go 1.25+ |
+| [secretssync](/packages/secretssync/) | Go binary | Go 1.25+ |
 
 ---
 
@@ -209,5 +217,10 @@ Or install individually — each package works on its own.
     title="Vendor Connectors"
     description="AWS, GCP, GitHub, Slack, AI APIs — with LangChain and MCP"
     href="/packages/vendor-connectors/"
+  />
+  <LinkCard
+    title="SecretSync"
+    description="Secret synchronization pipelines, GitHub Action usage, and Python integration"
+    href="/packages/secretssync/"
   />
 </CardGrid>

--- a/docs/src/content/docs/packages/index.mdx
+++ b/docs/src/content/docs/packages/index.mdx
@@ -7,7 +7,8 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 ## Extended Data Packages
 
-The Extended Data ecosystem provides four production-ready Python packages that work together seamlessly or independently.
+The Extended Data ecosystem provides four production-ready Python packages plus
+SecretSync, a Go-based operational package for secret synchronization.
 
 <CardGrid>
   <LinkCard
@@ -30,6 +31,11 @@ The Extended Data ecosystem provides four production-ready Python packages that 
     description="Universal connectors for AWS, GCP, GitHub, Slack, AI APIs"
     href="/packages/vendor-connectors/"
   />
+  <LinkCard
+    title="SecretSync"
+    description="Go-based secret synchronization pipeline with GitHub Action and Python integration"
+    href="/packages/secretssync/"
+  />
 </CardGrid>
 
 ---
@@ -45,6 +51,9 @@ pip install extended-data-types      # Core utilities
 pip install directed-inputs-class    # Input handling
 pip install lifecyclelogging         # Logging
 pip install vendor-connectors[all]   # All vendor connectors
+
+# SecretSync (Go)
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
 ```
 
 ---
@@ -124,6 +133,7 @@ print(encode_yaml(config))
 | [directed-inputs-class](https://pypi.org/project/directed-inputs-class/) | ![PyPI](https://img.shields.io/pypi/v/directed-inputs-class.svg) | 3.10+ | MIT |
 | [lifecyclelogging](https://pypi.org/project/lifecyclelogging/) | ![PyPI](https://img.shields.io/pypi/v/lifecyclelogging.svg) | 3.10+ | MIT |
 | [vendor-connectors](https://pypi.org/project/vendor-connectors/) | ![PyPI](https://img.shields.io/pypi/v/vendor-connectors.svg) | 3.10+ | MIT |
+| [SecretSync](https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync) | GitHub Release | Go 1.25+ | MIT |
 
 ---
 

--- a/docs/src/content/docs/packages/secretssync.mdx
+++ b/docs/src/content/docs/packages/secretssync.mdx
@@ -1,0 +1,172 @@
+---
+title: SecretSync
+description: Enterprise-grade Vault-to-cloud secret synchronization with a two-phase pipeline, GitHub Action support, and Python integration
+---
+
+import { Tabs, TabItem, Aside, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+**SecretSync** (`secretssync`) is the operational package in the Extended Data
+ecosystem: a Go-based secret synchronization pipeline built for Vault-to-cloud
+workflows, multi-account AWS environments, dry-run diffs, and CI/CD-friendly
+execution.
+
+[![GitHub Release](https://img.shields.io/github/v/release/jbcom/extended-data-library.svg)](https://github.com/jbcom/extended-data-library/releases)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jbcom/extended-data-library)](https://goreportcard.com/report/github.com/jbcom/extended-data-library)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+---
+
+<CardGrid>
+  <Card title="Two-phase pipeline" icon="branch">
+    Separate merge and sync phases make inheritance, aggregation, and dry-run
+    inspection predictable at scale.
+  </Card>
+  <Card title="Cloud-aware discovery" icon="seti:aws">
+    AWS Organizations and Identity Center discovery help target large account
+    fleets without hand-maintained account lists.
+  </Card>
+  <Card title="CI/CD ready" icon="seti:github">
+    GitHub Action support, structured output modes, exit codes, and diff views
+    make SecretSync suitable for automation-first workflows.
+  </Card>
+  <Card title="Python integration" icon="seti:python">
+    The recommended Python entry point is through `vendor-connectors[secrets]`,
+    which exposes SecretSync operations to Python applications and agent tools.
+  </Card>
+</CardGrid>
+
+---
+
+## Installation
+
+<Tabs>
+  <TabItem label="Go Binary">
+    ```bash
+    go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
+    ```
+  </TabItem>
+  <TabItem label="Local Build">
+    ```bash
+    git clone https://github.com/jbcom/extended-data-library.git
+    cd extended-data-library/packages/secretssync
+    make build
+    ```
+  </TabItem>
+  <TabItem label="Python via vendor-connectors">
+    ```bash
+    pip install vendor-connectors[secrets]
+    ```
+  </TabItem>
+</Tabs>
+
+---
+
+## What It Does
+
+- Synchronizes secrets between HashiCorp Vault and cloud secret stores.
+- Supports two-phase merge and sync workflows for inheritance-heavy setups.
+- Provides dry-run, diff, and exit-code modes for CI/CD pipelines.
+- Exposes metrics and health endpoints for operational monitoring.
+- Supports GitHub Action usage for repository-native automation.
+
+<Aside type="tip" title="Recommended Python usage">
+  If you need SecretSync from Python, use
+  [`vendor-connectors[secrets]`](https://pypi.org/project/vendor-connectors/)
+  instead of building directly against the Go bindings first.
+</Aside>
+
+---
+
+## Quick Start
+
+```bash
+# Validate a pipeline configuration
+secretsync validate --config pipeline.yaml
+
+# Dry run with CI-friendly exit codes
+secretsync pipeline --config pipeline.yaml --dry-run --exit-code
+
+# Execute the full pipeline
+secretsync pipeline --config pipeline.yaml
+```
+
+### Example Configuration
+
+```yaml
+vault:
+  address: "https://vault.example.com"
+  namespace: "admin"
+
+aws:
+  region: "us-east-1"
+  execution_role_pattern: "arn:aws:iam::{account_id}:role/SecretsSync"
+
+sources:
+  api-keys:
+    vault:
+      path: "secret/api-keys"
+
+targets:
+  Staging:
+    imports: [api-keys]
+    account_id: "111111111111"
+```
+
+---
+
+## GitHub Actions
+
+```yaml
+- name: Sync Secrets
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+  with:
+    config: config.yaml
+    dry-run: "false"
+    output-format: "github"
+  env:
+    VAULT_ROLE_ID: ${{ secrets.VAULT_ROLE_ID }}
+    VAULT_SECRET_ID: ${{ secrets.VAULT_SECRET_ID }}
+```
+
+This is the right path when you want repository-native secret promotion with
+dry-run annotations and CI/CD control-flow friendly exit codes.
+
+---
+
+## Python Integration
+
+```python
+from vendor_connectors.secrets import SecretsConnector
+
+connector = SecretsConnector()
+is_valid, message = connector.validate_config("pipeline.yaml")
+result = connector.dry_run("pipeline.yaml")
+
+if is_valid:
+    print(result.secrets_processed)
+```
+
+SecretSync tools are also exposed to LangChain, CrewAI, and related frameworks
+through the `vendor-connectors` package surface.
+
+---
+
+## Related Resources
+
+<CardGrid>
+  <LinkCard
+    title="Package Source"
+    description="Browse the Go package, examples, and deployment assets."
+    href="https://github.com/jbcom/extended-data-library/tree/main/packages/secretssync"
+  />
+  <LinkCard
+    title="GitHub Action Guide"
+    description="See the full CI/CD integration details and workflow examples."
+    href="https://github.com/jbcom/extended-data-library/blob/main/packages/secretssync/docs/GITHUB_ACTIONS.md"
+  />
+  <LinkCard
+    title="Package README"
+    description="Read the fuller SecretSync package documentation in the repo."
+    href="https://github.com/jbcom/extended-data-library/blob/main/packages/secretssync/README.md"
+  />
+</CardGrid>


### PR DESCRIPTION
## Summary
- add a first-class SecretSync package page under the docs site `packages/` section
- wire the homepage, package overview, and sidebar to the new package route
- keep `/api/secretsync/` as a compatibility page while pointing readers at the new canonical package overview

## Testing
- `git diff --check`
- `cd docs && npm run build`
