### PR TITLE
docs(site): add logging home link

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -214,6 +214,11 @@ Or install individually — each package works on its own.
     href="/packages/inputs/"
   />
   <LinkCard
+    title="Lifecycle Logging"
+    description="Structured logging with verbosity control, context markers, and message storage"
+    href="/packages/logging/"
+  />
+  <LinkCard
     title="Vendor Connectors"
     description="AWS, GCP, GitHub, Slack, AI APIs — with LangChain and MCP"
     href="/packages/vendor-connectors/"


### PR DESCRIPTION
## Summary
- add the missing Lifecycle Logging link card to the docs homepage quick-link section
- keep the homepage package navigation consistent with the rest of the docs site

## Testing
- `git diff --check`
- `cd docs && npm run build`
