### PR TITLE
docs(repo): simplify gh guidance and secretssync nav

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,8 +30,7 @@ cd packages/secretssync && go test ./...
 
 ## GitHub CLI
 
-Use `gh` directly with the existing local authentication context. Do not wrap
-local commands with `GH_TOKEN=...`.
+Use `gh` directly with the existing local authentication context.
 
 ```bash
 gh auth status

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,7 @@ tox -e py310-edt,py311-edt,py312-edt,py313-edt,py314-edt
 
 ## GitHub CLI
 
-Use `gh` directly with the existing local authentication context. Do not prefix
-local commands with `GH_TOKEN=...`.
+Use `gh` directly with the existing local authentication context.
 
 ```bash
 gh auth status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,7 @@ cd ..
 
 ## GitHub CLI
 
-Use `gh` directly with your existing local authentication context. Do not wrap
-local commands with `GH_TOKEN=...`.
+Use `gh` directly with your existing local authentication context.
 
 ```bash
 gh auth status

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ uv sync
 
 ### GitHub CLI
 
-Use `gh` directly with your existing local authentication context. Do not
-prefix local `gh` commands with `GH_TOKEN=...`.
+Use `gh` directly with your existing local authentication context.
 
 ```bash
 gh auth status

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -90,7 +90,6 @@ export default defineConfig({
           label: 'SecretSync',
           items: [
             { label: 'Overview', slug: 'packages/secretssync' },
-            { label: 'Legacy Overview Route', slug: 'api/secretsync' },
           ],
         },
         {

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -12,8 +12,7 @@ uv sync --all-extras
 
 ## GitHub CLI
 
-Use `gh` directly with your existing local authentication context. Do not
-prefix local commands with `GH_TOKEN=...`.
+Use `gh` directly with your existing local authentication context.
 
 ```bash
 gh auth status


### PR DESCRIPTION
## Summary
- simplify the live README, contributing, and agent instruction wording around local gh usage
- keep the docs sidebar focused on the canonical SecretSync package page
- leave the compatibility route in place without advertising it in navigation

## Validation
- git diff --check
- cd docs && npm run build
- rg -n -S "GH_TOKEN=|Python 3\.9\+|Legacy Overview Route|control-center|agentic-control|memory-bank|\.ruler|\.kiro|PACKAGE_NAME" README.md CONTRIBUTING.md AGENTS.md docs packages .github tools --glob "!**/node_modules/**" --glob "!**/.astro/**" --glob "!**/CHANGELOG.md"