### PR TITLE
fix(connectors): align exports and clean api docs warnings

### DIFF
--- a/docs/_static/jbcom-sphinx.css
+++ b/docs/_static/jbcom-sphinx.css
@@ -129,7 +129,7 @@ code, pre, .highlight {
 }
 
 /* =============================================================================
-   ReadTheDocs Theme Overrides
+   Sphinx theme compatibility overrides
    ============================================================================= */
 
 /* Main content area */

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -5,6 +5,9 @@
 # autodoc2 parses Python source with astroid (no imports needed),
 # making it reliable in CI where dependencies may not be installed.
 
+from docutils import nodes
+from sphinx_markdown_builder.translator import MarkdownTranslator
+
 # -- Project information -----------------------------------------------------
 project = "Extended Data Library"
 copyright = "2025-2026, Jon Bogaty"
@@ -53,6 +56,10 @@ autodoc2_render_plugin = "myst"
 
 # Hide inherited members and undocumented dunder methods by default
 autodoc2_hidden_objects = ["inherited", "dunder"]
+autodoc2_hidden_regexes = [
+    r"vendor_connectors\.anthropic\.ContentBlock\.type",
+    r"vendor_connectors\.anthropic\.Message\.type",
+]
 
 # Merge class and __init__ docstrings
 autodoc2_class_docstring = "merge"
@@ -80,3 +87,19 @@ myst_enable_extensions = [
     "tasklist",
 ]
 myst_heading_anchors = 3
+
+
+class PatchedMarkdownTranslator(MarkdownTranslator):
+    """Handle docutils nodes the markdown builder leaves unsupported."""
+
+    def visit_abbreviation(self, node: nodes.abbreviation) -> None:  # noqa: ARG002
+        """Treat abbreviation nodes as transparent wrappers around their text."""
+
+    def depart_abbreviation(self, node: nodes.abbreviation) -> None:  # noqa: ARG002
+        """Keep abbreviation node rendering as plain text in markdown output."""
+
+
+def setup(app):
+    """Register markdown translator patches for the docs pipeline."""
+
+    app.set_translator("markdown", PatchedMarkdownTranslator, override=True)

--- a/packages/directed-inputs-class/pyproject.toml
+++ b/packages/directed-inputs-class/pyproject.toml
@@ -78,7 +78,6 @@ source = ["src/directed_inputs_class"]
 branch = true
 parallel = true
 source = ["directed_inputs_class"]
-relative_files = true
 
 [tool.coverage.xml]
 output = "coverage.xml"

--- a/packages/directed-inputs-class/src/directed_inputs_class/decorators.py
+++ b/packages/directed-inputs-class/src/directed_inputs_class/decorators.py
@@ -16,6 +16,7 @@ python-terraform-bridge) to instantiate the classes safely.
 
 from __future__ import annotations
 
+import builtins
 import functools
 import inspect
 
@@ -176,7 +177,7 @@ def directed_inputs(
     from_stdin: bool = False,
     env_prefix: str | None = None,
     strip_env_prefix: bool = False,
-) -> Callable[[type[Any]], type[Any]]:
+) -> Callable[[builtins.type[Any]], builtins.type[Any]]:
     """Class decorator that injects DirectedInputsClass behavior."""
     base_options = {
         "inputs": inputs,
@@ -186,7 +187,7 @@ def directed_inputs(
         "strip_env_prefix": strip_env_prefix,
     }
 
-    def decorator(cls: type[Any]) -> type[Any]:
+    def decorator(cls: builtins.type[Any]) -> builtins.type[Any]:
         if getattr(cls, "__directed_inputs_enabled__", False):
             return cls
 
@@ -242,7 +243,7 @@ def directed_inputs(
     return decorator
 
 
-def _inject_proxies(cls: type[Any]) -> None:
+def _inject_proxies(cls: builtins.type[Any]) -> None:
     """Inject helper properties/methods for interacting with the context."""
 
     def _get_context(self: Any) -> InputContext:
@@ -266,7 +267,7 @@ def _inject_proxies(cls: type[Any]) -> None:
         cls.refresh_inputs = refresh_inputs
 
 
-def _wrap_instance_methods(cls: type[Any]) -> None:
+def _wrap_instance_methods(cls: builtins.type[Any]) -> None:
     """Wrap instance methods so missing parameters are auto-populated."""
     for name, attribute in list(cls.__dict__.items()):
         if _should_skip_method(name, attribute):

--- a/packages/extended-data-types/pyproject.toml
+++ b/packages/extended-data-types/pyproject.toml
@@ -90,7 +90,6 @@ source = ["src/extended_data_types"]
 branch = true
 parallel = true
 source = ["extended_data_types"]
-relative_files = true
 
 [tool.coverage.xml]
 output = "coverage.xml"

--- a/packages/extended-data-types/src/extended_data_types/map_data_type.py
+++ b/packages/extended-data-types/src/extended_data_types/map_data_type.py
@@ -6,6 +6,8 @@ dictionaries, and to convert keys from camelCase to snake_case.
 
 from __future__ import annotations
 
+import builtins
+
 from collections import defaultdict
 from collections.abc import Callable, Mapping, MutableMapping
 from typing import Any, TypeVar
@@ -296,7 +298,7 @@ class SortedDefaultDict(defaultdict[KT, VT], SortedDict[KT, VT]):  # type: ignor
 
 def get_default_dict(
     use_sorted_dict: bool = False,
-    default_type: type[dict[Any, Any]] = dict,
+    default_type: builtins.type[dict[Any, Any]] = dict,
     levels: int = 2,
 ) -> defaultdict[str, Any] | Any:
     """Create a nested `defaultdict` with the specified number of levels.

--- a/packages/extended-data-types/src/extended_data_types/splitter_utils.py
+++ b/packages/extended-data-types/src/extended_data_types/splitter_utils.py
@@ -10,13 +10,17 @@ Functions:
 
 from __future__ import annotations
 
+import builtins
+
 from collections import defaultdict
 from typing import Any
 
 from extended_data_types.type_utils import typeof
 
 
-def split_list_by_type(input_list: list[Any], primitive_only: bool = False) -> defaultdict[type, list[Any]]:
+def split_list_by_type(
+    input_list: list[Any], primitive_only: bool = False
+) -> defaultdict[builtins.type[Any], list[Any]]:
     """Split a list by the type of its items, with an option to categorize by primitive types only.
 
     Args:
@@ -27,13 +31,15 @@ def split_list_by_type(input_list: list[Any], primitive_only: bool = False) -> d
     Returns:
         DefaultDict[type, List[Any]]: A defaultdict storing lists of elements categorized by their type.
     """
-    result: defaultdict[type, list[Any]] = defaultdict(list)
+    result: defaultdict[builtins.type[Any], list[Any]] = defaultdict(list)
     for item in input_list:
         result[typeof(item, primitive_only=primitive_only)].append(item)
     return result
 
 
-def split_dict_by_type(input_dict: dict[Any, Any], primitive_only: bool = False) -> defaultdict[type, dict[Any, Any]]:
+def split_dict_by_type(
+    input_dict: dict[Any, Any], primitive_only: bool = False
+) -> defaultdict[builtins.type[Any], dict[Any, Any]]:
     """Split a dictionary by the type of its values, with an option to categorize by primitive types only.
 
     Args:
@@ -44,7 +50,7 @@ def split_dict_by_type(input_dict: dict[Any, Any], primitive_only: bool = False)
     Returns:
         DefaultDict[type, Dict[Any, Any]]: A defaultdict storing dictionaries of elements categorized by their type.
     """
-    result: defaultdict[type, dict[Any, Any]] = defaultdict(dict)
+    result: defaultdict[builtins.type[Any], dict[Any, Any]] = defaultdict(dict)
     for key, value in input_dict.items():
         result[typeof(value, primitive_only=primitive_only)][key] = value
     return result

--- a/packages/extended-data-types/src/extended_data_types/stack_utils.py
+++ b/packages/extended-data-types/src/extended_data_types/stack_utils.py
@@ -6,6 +6,7 @@ methods and their docstrings for a class.
 
 from __future__ import annotations
 
+import builtins
 import re
 import sys
 
@@ -47,7 +48,7 @@ def filter_methods(methods: list[str]) -> list[str]:
     return [method for method in methods if not method.startswith("_")]
 
 
-def get_available_methods(cls: type[Any]) -> dict[str, str | None]:
+def get_available_methods(cls: builtins.type[Any]) -> dict[str, str | None]:
     """Gets available methods and their docstrings for a class.
 
     An "available method" is a public method that:

--- a/packages/extended-data-types/src/extended_data_types/type_utils.py
+++ b/packages/extended-data-types/src/extended_data_types/type_utils.py
@@ -31,6 +31,7 @@ Constants:
 
 from __future__ import annotations
 
+import builtins
 import datetime
 import os
 import pathlib
@@ -88,7 +89,7 @@ class ConversionError(ValueError):
         in different Python versions.
     """
 
-    def __init__(self, expected_type: type, value: Any):
+    def __init__(self, expected_type: builtins.type[Any], value: Any):
         """Initialize the ConversionError with expected type and value.
 
         Args:
@@ -311,7 +312,7 @@ def strtotime(val: str, raise_on_error: bool = False) -> datetime.time | None:
     return None
 
 
-def get_default_value_for_type(input_type: type) -> Any:
+def get_default_value_for_type(input_type: builtins.type[Any]) -> Any:
     """Returns the default value for a given type."""
     if input_type is list:
         return []
@@ -322,7 +323,7 @@ def get_default_value_for_type(input_type: type) -> Any:
     return None
 
 
-def get_primitive_type_for_instance_type(value: Any) -> type:
+def get_primitive_type_for_instance_type(value: Any) -> builtins.type[Any]:
     """Gets the primitive type for a given value."""
     if isinstance(value, (bool, int, float, str, bytes, bytearray)):
         return type(value)
@@ -335,7 +336,7 @@ def get_primitive_type_for_instance_type(value: Any) -> type:
     return type(None) if value is None else object
 
 
-def typeof(item: Any, primitive_only: bool = False) -> type:
+def typeof(item: Any, primitive_only: bool = False) -> builtins.type[Any]:
     """Determines either the primitive or exact type of a given value."""
     return get_primitive_type_for_instance_type(item) if primitive_only else type(item)
 

--- a/packages/lifecyclelogging/pyproject.toml
+++ b/packages/lifecyclelogging/pyproject.toml
@@ -74,7 +74,6 @@ source = ["src/lifecyclelogging"]
 branch = true
 parallel = true
 source = ["lifecyclelogging"]
-relative_files = true
 
 [tool.coverage.xml]
 output = "coverage.xml"

--- a/packages/vendor-connectors/README.md
+++ b/packages/vendor-connectors/README.md
@@ -73,12 +73,12 @@ cursor = vc.get_cursor_client()
 ### Using Individual Connectors
 
 ```python
-from vendor_connectors import AWSConnector, GithubConnector
+from vendor_connectors import AWSConnector, GitHubConnector
 
 aws = AWSConnector(execution_role_arn="arn:aws:iam::123456789012:role/MyRole")
 s3 = aws.get_aws_client("s3")
 
-github = GithubConnector(
+github = GitHubConnector(
     github_owner="myorg",
     github_repo="myrepo",
     github_token=os.getenv("GITHUB_TOKEN")

--- a/packages/vendor-connectors/pyproject.toml
+++ b/packages/vendor-connectors/pyproject.toml
@@ -329,7 +329,6 @@ omit = [
     # Test files
     "tests/*",
 ]
-relative_files = true
 
 [tool.coverage.xml]
 output = "coverage.xml"

--- a/packages/vendor-connectors/pyproject.toml
+++ b/packages/vendor-connectors/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # === Core dependencies (minimal - HTTP client foundation) ===
-    # jbcom ecosystem
+    # Shared monorepo packages
     "extended-data-types",
     "lifecyclelogging",
     "directed-inputs-class",

--- a/packages/vendor-connectors/src/vendor_connectors/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/__init__.py
@@ -1,4 +1,4 @@
-"""Vendor Connectors - Universal vendor connectors for the jbcom ecosystem.
+"""Vendor Connectors - shared connectors for cloud, SaaS, and AI platforms.
 
 This package provides modular connectors for various cloud providers and services:
 - Anthropic: Claude AI API and Agent SDK (NEW)
@@ -10,7 +10,6 @@ This package provides modular connectors for various cloud providers and service
 - Slack: Channel and message operations
 - Vault: HashiCorp Vault secret management
 - Zoom: User and meeting management
-- Meshy: AI 3D asset generation
 
 Usage:
     # Basic connector (session management + secrets)
@@ -45,7 +44,7 @@ Usage:
     rigged = rigging.rig(model.id)
     animated = animate.apply(rigged.id, animation_id=0)
 
-    # AI tools for agents
+    # AI tools and automation integrations
     from vendor_connectors.meshy.tools import get_tools, get_crewai_tools
     from vendor_connectors.meshy.mcp import create_server, run_server
 """
@@ -97,8 +96,9 @@ except ImportError:
 
 # GitHub connector (requires: pip install vendor-connectors[github])
 try:
-    from vendor_connectors.github import GithubConnector
+    from vendor_connectors.github import GitHubConnector, GithubConnector
 except ImportError:
+    GitHubConnector = None  # type: ignore[misc, assignment]
     GithubConnector = None  # type: ignore[misc, assignment]
 
 # Google connector (requires: pip install vendor-connectors[google])
@@ -142,6 +142,7 @@ __all__ = [
     "AnthropicConnector",
     "CursorConnector",
     # Other connectors
+    "GitHubConnector",
     "GithubConnector",
     "GoogleBillingMixin",
     "GoogleCloudMixin",

--- a/packages/vendor-connectors/src/vendor_connectors/ai_tools.py
+++ b/packages/vendor-connectors/src/vendor_connectors/ai_tools.py
@@ -6,12 +6,14 @@ that are compatible with the Vercel AI SDK and other modern AI frameworks.
 
 from __future__ import annotations
 
+import builtins
+
 from typing import Any
 
 from pydantic import BaseModel
 
 
-def get_pydantic_schema(model: type[BaseModel]) -> dict[str, Any]:
+def get_pydantic_schema(model: builtins.type[BaseModel]) -> dict[str, Any]:
     """Generate a Vercel AI SDK-compatible JSON schema from a Pydantic model.
 
     This function removes the top-level 'title' and 'description' fields,

--- a/packages/vendor-connectors/src/vendor_connectors/anthropic/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/anthropic/__init__.py
@@ -1,4 +1,4 @@
-"""Anthropic Connector - Claude AI SDK wrapper for the jbcom ecosystem.
+"""Anthropic connector for Claude APIs and local agent execution.
 
 This connector provides Python access to Anthropic's Claude AI, including
 the Claude Agent SDK for sandbox/local agent execution.

--- a/packages/vendor-connectors/src/vendor_connectors/aws/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/aws/__init__.py
@@ -1,4 +1,4 @@
-"""AWS Connector using jbcom ecosystem packages.
+"""AWS connector built on shared packages from this monorepo.
 
 This package provides AWS operations organized into submodules:
 - organizations: AWS Organizations and Control Tower account management

--- a/packages/vendor-connectors/src/vendor_connectors/base.py
+++ b/packages/vendor-connectors/src/vendor_connectors/base.py
@@ -27,6 +27,7 @@ Usage:
 
 from __future__ import annotations
 
+import builtins
 import threading
 import time
 
@@ -100,8 +101,8 @@ class VendorConnectorBase(DirectedInputsClass, ABC):
     # Each subclass gets its own lock and timestamp to avoid cross-connector interference.
     # This is intentionally class-level (not instance-level) so all instances of the same
     # connector type share rate limiting, but different connector types are independent.
-    _rate_limit_locks: ClassVar[dict[type, threading.Lock]] = {}
-    _last_request_times: ClassVar[dict[type, float]] = {}
+    _rate_limit_locks: ClassVar[dict[builtins.type[VendorConnectorBase], threading.Lock]] = {}
+    _last_request_times: ClassVar[dict[builtins.type[VendorConnectorBase], float]] = {}
 
     def __init__(
         self,
@@ -143,7 +144,7 @@ class VendorConnectorBase(DirectedInputsClass, ABC):
         # Tool registry for LangChain/MCP
         self._tools: list[StructuredTool] = []
         self._tool_functions: dict[str, Callable] = {}
-        self._tool_schemas: dict[str, type[BaseModel]] = {}
+        self._tool_schemas: dict[str, builtins.type[BaseModel]] = {}
 
     @property
     def api_key(self) -> str:
@@ -333,7 +334,7 @@ class VendorConnectorBase(DirectedInputsClass, ABC):
         func: Callable,
         name: str | None = None,
         description: str | None = None,
-        schema: type[BaseModel] | None = None,
+        schema: builtins.type[BaseModel] | None = None,
     ) -> None:
         """Register a function as a LangChain tool.
 

--- a/packages/vendor-connectors/src/vendor_connectors/cursor/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/cursor/__init__.py
@@ -1,7 +1,7 @@
 """Cursor Connector - HTTP client for Cursor Background Agent API.
 
 This connector provides Python access to the Cursor Background Agent API for
-managing AI coding agents, following the patterns established in the jbcom ecosystem.
+managing AI coding agents through the shared connector patterns in this monorepo.
 
 Usage:
     from vendor_connectors.cursor import CursorConnector

--- a/packages/vendor-connectors/src/vendor_connectors/github/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/github/__init__.py
@@ -1,4 +1,4 @@
-"""Github Connector using jbcom ecosystem packages."""
+"""GitHub connector using shared packages from this monorepo."""
 
 from __future__ import annotations
 
@@ -28,7 +28,7 @@ FilePath = str | bytes | os.PathLike[Any]
 
 
 def get_github_api_error(exc: GithubException) -> str | None:
-    """Extract error message from Github exception."""
+    """Extract error message from a GitHub exception."""
     data = getattr(exc, "data", {})
     return data.get("message", None)
 
@@ -37,7 +37,7 @@ DEFAULT_PER_PAGE = 100
 
 
 class GithubConnector(VendorConnectorBase):
-    """Github connector for repository operations."""
+    """GitHub connector for repository operations."""
 
     def __init__(
         self,

--- a/packages/vendor-connectors/src/vendor_connectors/github/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/github/__init__.py
@@ -980,8 +980,12 @@ from vendor_connectors.github.tools import (
 )
 
 
+GitHubConnector = GithubConnector
+
+
 __all__ = [
     # Core connector
+    "GitHubConnector",
     "GithubConnector",
     "get_crewai_tools",
     "get_langchain_tools",

--- a/packages/vendor-connectors/src/vendor_connectors/google/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/google/__init__.py
@@ -1,4 +1,4 @@
-"""Google Cloud and Workspace Connector using jbcom ecosystem packages."""
+"""Google Cloud and Workspace connector built on shared monorepo packages."""
 
 from __future__ import annotations
 

--- a/packages/vendor-connectors/src/vendor_connectors/google/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/google/__init__.py
@@ -533,7 +533,20 @@ from vendor_connectors.google.constants import (
     GCP_REQUIRED_ROLES,
     GCP_SECURITY_PROJECT,
 )
+from vendor_connectors.google.jules import (
+    JulesConnector,
+    JulesError,
+    Session,
+    SessionState,
+    Source,
+)
 from vendor_connectors.google.services import GoogleServicesMixin
+from vendor_connectors.google.tools import (
+    get_crewai_tools,
+    get_langchain_tools,
+    get_strands_tools,
+    get_tools,
+)
 from vendor_connectors.google.workspace import GoogleWorkspaceMixin
 
 
@@ -548,17 +561,20 @@ class GoogleConnectorFull(
     """
 
 
-from vendor_connectors.google.tools import (
-    get_crewai_tools,
-    get_langchain_tools,
-    get_strands_tools,
-    get_tools,
-)
+class GoogleCloudConnector(GoogleConnector, GoogleCloudMixin):
+    """Google connector focused on Cloud Resource Manager and IAM operations."""
+
+
+class GoogleWorkspaceConnector(GoogleConnector, GoogleWorkspaceMixin):
+    """Google connector focused on Admin Directory user and group operations."""
+
+
+class GoogleBillingConnector(GoogleConnector, GoogleBillingMixin):
+    """Google connector focused on Cloud Billing account and project billing operations."""
 
 
 __all__ = [
     "DEFAULT_DOMAIN",
-    # Constants
     "DEFAULT_SCOPES",
     "DEFAULT_USER_OUS",
     "GCP_KMS",
@@ -566,41 +582,22 @@ __all__ = [
     "GCP_REQUIRED_ORGANIZATION_ROLES",
     "GCP_REQUIRED_ROLES",
     "GCP_SECURITY_PROJECT",
+    "GoogleBillingConnector",
     "GoogleBillingMixin",
+    "GoogleCloudConnector",
     "GoogleCloudMixin",
-    # Core connector classes
     "GoogleConnector",
     "GoogleConnectorFull",
     "GoogleServicesMixin",
-    # Mixins
-    "GoogleWorkspaceMixin",
-    "get_crewai_tools",
-    "get_langchain_tools",
-    "get_strands_tools",
-    # Tools
-    "get_tools",
-]
-
-# Jules AI Agent
-from vendor_connectors.google.jules import (
-    JulesConnector,
-    JulesError,
-    Session,
-    SessionState,
-    Source,
-)
-
-
-__all__ = [
-    "GoogleBillingConnector",
-    "GoogleCloudConnector",
-    # Existing exports...
-    "GoogleConnector",
     "GoogleWorkspaceConnector",
-    # Jules exports
+    "GoogleWorkspaceMixin",
     "JulesConnector",
     "JulesError",
     "Session",
     "SessionState",
     "Source",
+    "get_crewai_tools",
+    "get_langchain_tools",
+    "get_strands_tools",
+    "get_tools",
 ]

--- a/packages/vendor-connectors/src/vendor_connectors/mcp.py
+++ b/packages/vendor-connectors/src/vendor_connectors/mcp.py
@@ -20,6 +20,7 @@ client with zero custom glue code - just standard MCP over stdio.
 
 from __future__ import annotations
 
+import builtins
 import inspect
 import json
 import sys
@@ -89,14 +90,14 @@ def _get_method_schema(method: Callable) -> dict[str, Any]:
     }
 
 
-def _get_public_methods(connector_class: type) -> list[tuple[str, Callable]]:
+def _get_public_methods(connector_class: builtins.type[Any]) -> list[tuple[str, Callable]]:
     """Get public methods from a connector class (excluding dunder and private)."""
     methods = []
     for name in dir(connector_class):
         if name.startswith("_"):
             continue
         attr = getattr(connector_class, name, None)
-        if callable(attr) and not isinstance(attr, type):
+        if callable(attr) and not isinstance(attr, builtins.type):
             methods.append((name, attr))
     return methods
 

--- a/packages/vendor-connectors/src/vendor_connectors/meshy/connector.py
+++ b/packages/vendor-connectors/src/vendor_connectors/meshy/connector.py
@@ -1,7 +1,7 @@
 """Meshy AI Connector - HTTP client for Meshy AI 3D generation API.
 
 This connector provides Python access to Meshy AI's 3D asset generation API,
-following the patterns established in the jbcom ecosystem.
+following the shared connector patterns used across this monorepo.
 """
 
 from __future__ import annotations

--- a/packages/vendor-connectors/src/vendor_connectors/registry.py
+++ b/packages/vendor-connectors/src/vendor_connectors/registry.py
@@ -30,6 +30,8 @@ Entry Points (in pyproject.toml):
 
 from __future__ import annotations
 
+import builtins
+
 from typing import TYPE_CHECKING, Any
 
 
@@ -37,17 +39,17 @@ if TYPE_CHECKING:
     from vendor_connectors.base import VendorConnectorBase
 
 # Cache for discovered connectors
-_connector_cache: dict[str, type[VendorConnectorBase]] | None = None
+_connector_cache: dict[str, builtins.type[VendorConnectorBase]] | None = None
 
 
-def _discover_connectors() -> dict[str, type[VendorConnectorBase]]:
+def _discover_connectors() -> dict[str, builtins.type[VendorConnectorBase]]:
     """Discover all registered connectors via entry points."""
     global _connector_cache
 
     if _connector_cache is not None:
         return _connector_cache
 
-    connectors: dict[str, type[VendorConnectorBase]] = {}
+    connectors: dict[str, builtins.type[VendorConnectorBase]] = {}
 
     # Python 3.10+ uses importlib.metadata
     from importlib.metadata import entry_points
@@ -71,7 +73,7 @@ def _discover_connectors() -> dict[str, type[VendorConnectorBase]]:
     return connectors
 
 
-def _register_builtins(connectors: dict[str, type[VendorConnectorBase]]) -> None:
+def _register_builtins(connectors: dict[str, builtins.type[VendorConnectorBase]]) -> None:
     """Register built-in connectors that may not be in entry points yet."""
     builtins = {
         # Google connectors
@@ -105,7 +107,7 @@ def _register_builtins(connectors: dict[str, type[VendorConnectorBase]]) -> None
             pass  # Optional dependency not installed
 
 
-def list_connectors() -> dict[str, type[VendorConnectorBase]]:
+def list_connectors() -> dict[str, builtins.type[VendorConnectorBase]]:
     """List all available connectors.
 
     Returns:
@@ -114,7 +116,7 @@ def list_connectors() -> dict[str, type[VendorConnectorBase]]:
     return _discover_connectors().copy()
 
 
-def get_connector_class(name: str) -> type[VendorConnectorBase]:
+def get_connector_class(name: str) -> builtins.type[VendorConnectorBase]:
     """Get a connector class by name.
 
     Args:

--- a/packages/vendor-connectors/src/vendor_connectors/registry.py
+++ b/packages/vendor-connectors/src/vendor_connectors/registry.py
@@ -75,7 +75,7 @@ def _discover_connectors() -> dict[str, builtins.type[VendorConnectorBase]]:
 
 def _register_builtins(connectors: dict[str, builtins.type[VendorConnectorBase]]) -> None:
     """Register built-in connectors that may not be in entry points yet."""
-    builtins = {
+    builtin_connectors = {
         # Google connectors
         "jules": ("vendor_connectors.google.jules", "JulesConnector"),
         "google": ("vendor_connectors.google", "GoogleConnector"),
@@ -84,7 +84,7 @@ def _register_builtins(connectors: dict[str, builtins.type[VendorConnectorBase]]
         "google_billing": ("vendor_connectors.google", "GoogleBillingConnector"),
         # Other connectors
         "cursor": ("vendor_connectors.cursor", "CursorConnector"),
-        "github": ("vendor_connectors.github", "GithubConnector"),
+        "github": ("vendor_connectors.github", "GitHubConnector"),
         "meshy": ("vendor_connectors.meshy", "MeshyConnector"),
         "anthropic": ("vendor_connectors.anthropic", "AnthropicConnector"),
         "aws": ("vendor_connectors.aws", "AWSConnector"),
@@ -93,7 +93,7 @@ def _register_builtins(connectors: dict[str, builtins.type[VendorConnectorBase]]
         "vault": ("vendor_connectors.vault", "VaultConnector"),
     }
 
-    for name, (module_path, class_name) in builtins.items():
+    for name, (module_path, class_name) in builtin_connectors.items():
         if name in connectors:
             continue  # Entry point takes precedence
         try:

--- a/packages/vendor-connectors/src/vendor_connectors/slack/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/slack/__init__.py
@@ -1,4 +1,4 @@
-"""Slack Connector using jbcom ecosystem packages."""
+"""Slack connector built on shared packages from this monorepo."""
 
 from __future__ import annotations
 

--- a/packages/vendor-connectors/src/vendor_connectors/vault/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/vault/__init__.py
@@ -1,4 +1,4 @@
-"""Vault Connector using jbcom ecosystem packages."""
+"""Vault connector built on shared packages from this monorepo."""
 
 from __future__ import annotations
 

--- a/packages/vendor-connectors/src/vendor_connectors/zoom/__init__.py
+++ b/packages/vendor-connectors/src/vendor_connectors/zoom/__init__.py
@@ -1,4 +1,4 @@
-"""Zoom Connector using jbcom ecosystem packages."""
+"""Zoom connector built on shared packages from this monorepo."""
 
 from __future__ import annotations
 

--- a/packages/vendor-connectors/tests/test_connectors.py
+++ b/packages/vendor-connectors/tests/test_connectors.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vendor_connectors.connectors import VendorConnectors
+from vendor_connectors.registry import _register_builtins
 
 
 # Helper to check if optional dependencies are available
@@ -254,3 +255,22 @@ class TestVendorConnectors:
         if not _has_module("github"):
             with pytest.raises(ImportError, match="PyGithub"):
                 vc.get_github_client()
+
+    def test_register_builtins_includes_specialized_google_connectors(self):
+        """Registry builtins expose the advertised specialized Google connectors."""
+        connectors = {}
+
+        _register_builtins(connectors)
+
+        assert connectors["google"].__name__ == "GoogleConnector"
+        assert connectors["google_cloud"].__name__ == "GoogleCloudConnector"
+        assert connectors["google_workspace"].__name__ == "GoogleWorkspaceConnector"
+        assert connectors["google_billing"].__name__ == "GoogleBillingConnector"
+
+    def test_register_builtins_loads_github_entrypoint_name(self):
+        """Registry builtins keep the GitHub connector spelling compatible with entry points."""
+        connectors = {}
+
+        _register_builtins(connectors)
+
+        assert connectors["github"].__name__ == "GithubConnector"

--- a/packages/vendor-connectors/tests/test_github_connector.py
+++ b/packages/vendor-connectors/tests/test_github_connector.py
@@ -1,14 +1,19 @@
-"""Tests for GithubConnector."""
+"""Tests for GitHub connector aliases and behavior."""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from vendor_connectors import GitHubConnector
 from vendor_connectors.github import GithubConnector
 
 
 class TestGithubConnector:
-    """Test suite for GithubConnector."""
+    """Test suite for GitHub connector behavior."""
+
+    def test_root_export_alias_points_to_same_connector(self):
+        """The canonical root export and legacy alias should resolve to the same class."""
+        assert GitHubConnector is GithubConnector
 
     @patch("vendor_connectors.github.Github")
     def test_init_with_repo(self, mock_github_class, base_connector_kwargs):

--- a/packages/vendor-connectors/tests/test_google_connector.py
+++ b/packages/vendor-connectors/tests/test_google_connector.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from vendor_connectors.google import GoogleConnector
+from vendor_connectors.google import (
+    GoogleBillingConnector,
+    GoogleCloudConnector,
+    GoogleConnector,
+    GoogleConnectorFull,
+    GoogleWorkspaceConnector,
+)
 
 
 def _service_account():
@@ -222,3 +228,20 @@ class TestGoogleConnector:
         assert result["keepers@example.com"]["suspended"] is True
         assert "team@example.com" in result
         assert result["team@example.com"]["primaryEmail"] == "team@example.com"
+
+    def test_specialized_connector_exports_match_available_operations(self, base_connector_kwargs):
+        """Specialized Google connectors expose the operations their entry points advertise."""
+        service_account = _service_account()
+
+        cloud = GoogleCloudConnector(service_account_info=service_account, **base_connector_kwargs)
+        workspace = GoogleWorkspaceConnector(service_account_info=service_account, **base_connector_kwargs)
+        billing = GoogleBillingConnector(service_account_info=service_account, **base_connector_kwargs)
+        full = GoogleConnectorFull(service_account_info=service_account, **base_connector_kwargs)
+
+        assert hasattr(cloud, "list_projects")
+        assert hasattr(workspace, "list_users")
+        assert hasattr(billing, "list_billing_accounts")
+
+        assert hasattr(full, "list_projects")
+        assert hasattr(full, "list_users")
+        assert hasattr(full, "list_billing_accounts")

--- a/tox.ini
+++ b/tox.ini
@@ -28,12 +28,14 @@ python =
 
 [testenv:edt]
 description = Test extended-data-types
-changedir = packages/extended-data-types
+changedir = {toxinidir}
 skip_install = true
 deps = {toxinidir}/packages/extended-data-types[tests]
 setenv =
     PYTHONPATH = {toxinidir}/packages/extended-data-types/src
-commands = pytest tests --cov --cov-report=xml --cov-report=term-missing {posargs}
+    COVERAGE_FILE = {toxinidir}/packages/extended-data-types/.coverage
+commands =
+    pytest packages/extended-data-types/tests --cov={toxinidir}/packages/extended-data-types/src/extended_data_types --cov-report=xml:{toxinidir}/packages/extended-data-types/coverage.xml --cov-report=term-missing {posargs}
 
 [testenv:py{310,311,312,313,314}-edt]
 description = Test extended-data-types on {basepython}
@@ -55,30 +57,36 @@ commands =
 
 [testenv:logging]
 description = Test lifecyclelogging
-changedir = packages/lifecyclelogging
+changedir = {toxinidir}
 skip_install = true
 deps = {toxinidir}/packages/lifecyclelogging[tests]
 setenv =
     PYTHONPATH = {toxinidir}/packages/lifecyclelogging/src
-commands = pytest tests --cov --cov-report=xml --cov-report=term-missing {posargs}
+    COVERAGE_FILE = {toxinidir}/packages/lifecyclelogging/.coverage
+commands =
+    pytest packages/lifecyclelogging/tests --cov={toxinidir}/packages/lifecyclelogging/src/lifecyclelogging --cov-report=xml:{toxinidir}/packages/lifecyclelogging/coverage.xml --cov-report=term-missing {posargs}
 
 [testenv:inputs]
 description = Test directed-inputs-class
-changedir = packages/directed-inputs-class
+changedir = {toxinidir}
 skip_install = true
 deps = {toxinidir}/packages/directed-inputs-class[tests]
 setenv =
     PYTHONPATH = {toxinidir}/packages/directed-inputs-class/src
-commands = pytest tests --cov --cov-report=xml --cov-report=term-missing {posargs}
+    COVERAGE_FILE = {toxinidir}/packages/directed-inputs-class/.coverage
+commands =
+    pytest packages/directed-inputs-class/tests --cov={toxinidir}/packages/directed-inputs-class/src/directed_inputs_class --cov-report=xml:{toxinidir}/packages/directed-inputs-class/coverage.xml --cov-report=term-missing {posargs}
 
 [testenv:connectors]
 description = Test vendor-connectors
-changedir = packages/vendor-connectors
+changedir = {toxinidir}
 skip_install = true
 deps = {toxinidir}/packages/vendor-connectors[tests,aws,google,github,slack,vault,anthropic,mcp]
 setenv =
     PYTHONPATH = {toxinidir}/packages/vendor-connectors/src
-commands = pytest tests --cov --cov-report=xml --cov-report=term-missing {posargs}
+    COVERAGE_FILE = {toxinidir}/packages/vendor-connectors/.coverage
+commands =
+    pytest packages/vendor-connectors/tests --cov={toxinidir}/packages/vendor-connectors/src/vendor_connectors --cov-report=xml:{toxinidir}/packages/vendor-connectors/coverage.xml --cov-report=term-missing {posargs}
 
 # ── Quality environments ──────────────────────────────
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,8 @@ description = Test extended-data-types
 changedir = packages/extended-data-types
 skip_install = true
 deps = {toxinidir}/packages/extended-data-types[tests]
+setenv =
+    PYTHONPATH = {toxinidir}/packages/extended-data-types/src
 commands = pytest tests --cov --cov-report=xml --cov-report=term-missing {posargs}
 
 [testenv:py{310,311,312,313,314}-edt]
@@ -45,6 +47,8 @@ description = Run extended-data-types example scripts
 changedir = packages/extended-data-types
 skip_install = true
 deps = {toxinidir}/packages/extended-data-types[tests]
+setenv =
+    PYTHONPATH = {toxinidir}/packages/extended-data-types/src
 allowlist_externals = bash
 commands =
     bash -c 'set -euo pipefail; for example in $(find examples -maxdepth 1 -type f -name "*.py" | sort); do echo "Running ${example}"; python "${example}"; done'
@@ -54,6 +58,8 @@ description = Test lifecyclelogging
 changedir = packages/lifecyclelogging
 skip_install = true
 deps = {toxinidir}/packages/lifecyclelogging[tests]
+setenv =
+    PYTHONPATH = {toxinidir}/packages/lifecyclelogging/src
 commands = pytest tests --cov --cov-report=xml --cov-report=term-missing {posargs}
 
 [testenv:inputs]
@@ -61,6 +67,8 @@ description = Test directed-inputs-class
 changedir = packages/directed-inputs-class
 skip_install = true
 deps = {toxinidir}/packages/directed-inputs-class[tests]
+setenv =
+    PYTHONPATH = {toxinidir}/packages/directed-inputs-class/src
 commands = pytest tests --cov --cov-report=xml --cov-report=term-missing {posargs}
 
 [testenv:connectors]
@@ -68,6 +76,8 @@ description = Test vendor-connectors
 changedir = packages/vendor-connectors
 skip_install = true
 deps = {toxinidir}/packages/vendor-connectors[tests,aws,google,github,slack,vault,anthropic,mcp]
+setenv =
+    PYTHONPATH = {toxinidir}/packages/vendor-connectors/src
 commands = pytest tests --cov --cov-report=xml --cov-report=term-missing {posargs}
 
 # ── Quality environments ──────────────────────────────


### PR DESCRIPTION
## Summary
- wire the advertised specialized Google connectors into the actual package exports and registry tests
- restore GitHub connector entrypoint compatibility with a `GitHubConnector` alias
- remove the remaining Sphinx API warning classes by hiding the anthropic `type` field targets and patching the markdown translator for abbreviation nodes

## Validation
- `tox -e lint`
- `tox -r -e connectors`
- `tox -e docs`
- `bash tools/sphinx-to-astro.sh && cd docs && npm run build`