### PR TITLE
docs(secretssync): align Python and CLI contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@ A collection of high-performance Python libraries and tools for data processing,
 ## Quick Start
 
 ```bash
-# Install any package directly
+# Python packages
 pip install extended-data-types
 pip install lifecyclelogging
 pip install directed-inputs-class
 pip install vendor-connectors
+
+# Python integration for SecretSync workflows
+pip install vendor-connectors[secrets]
+
+# SecretSync CLI
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
 ```
 
 ## Monorepo Structure

--- a/docs/plans/2026-02-24-monorepo-migration-design.md
+++ b/docs/plans/2026-02-24-monorepo-migration-design.md
@@ -7,7 +7,7 @@ Migrate all extended-data-library Python packages and the Go secretssync binary 
 ## Target Structure
 
 ```
-extended-data-types/                    # repo root
+extended-data-library/                  # repo root
 ├── nx.json                             # Nx workspace config
 ├── package.json                        # Nx + plugins (root)
 ├── pyproject.toml                      # uv workspace root
@@ -86,7 +86,7 @@ docs (builds from all packages)
 [project]
 name = "extended-data-library"
 version = "0.0.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [tool.uv]
 workspace = { members = [

--- a/docs/src/content/docs/api/secretsync.mdx
+++ b/docs/src/content/docs/api/secretsync.mdx
@@ -12,8 +12,13 @@ description: Vault-to-cloud secret synchronization tool written in Go
 ## Installation
 
 ```bash
-go install github.com/jbcom/extended-data-library/packages/secretssync@latest
+go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@latest
 ```
+
+For Python usage, prefer
+[`vendor-connectors[secrets]`](https://pypi.org/project/vendor-connectors/)
+and keep the `secretsync` CLI available in the environment for pipeline
+execution.
 
 ## Usage
 

--- a/docs/src/content/docs/packages/secretssync.mdx
+++ b/docs/src/content/docs/packages/secretssync.mdx
@@ -32,6 +32,7 @@ execution.
   <Card title="Python integration" icon="seti:python">
     The recommended Python entry point is through `vendor-connectors[secrets]`,
     which exposes SecretSync operations to Python applications and agent tools.
+    Runtime execution still depends on the `secretsync` CLI or native bindings.
   </Card>
 </CardGrid>
 
@@ -72,7 +73,9 @@ execution.
 <Aside type="tip" title="Recommended Python usage">
   If you need SecretSync from Python, use
   [`vendor-connectors[secrets]`](https://pypi.org/project/vendor-connectors/)
-  instead of building directly against the Go bindings first.
+  instead of building directly against the Go bindings first. Keep the
+  `secretsync` CLI installed, or build the native bindings, when you need to
+  execute the pipeline from Python.
 </Aside>
 
 ---

--- a/docs/src/content/docs/packages/vendor-connectors.mdx
+++ b/docs/src/content/docs/packages/vendor-connectors.mdx
@@ -29,6 +29,7 @@ import { Tabs, TabItem, Aside, Card, CardGrid } from '@astrojs/starlight/compone
     pip install vendor-connectors[slack]
     pip install vendor-connectors[vault]
     pip install vendor-connectors[anthropic]
+    pip install vendor-connectors[secrets]
     pip install vendor-connectors[meshy]
     ```
   </TabItem>
@@ -47,6 +48,12 @@ import { Tabs, TabItem, Aside, Card, CardGrid } from '@astrojs/starlight/compone
 The `crewai` extra currently resolves to `crewai[tools] >= 1.14.2rc1` because that is the first upstream line carrying the patched `uv` and `requests` floors. Once CrewAI publishes the same fix on a stable release line, this package can move back to a stable minimum.
 </Aside>
 
+<Aside type="tip">
+The `secrets` extra installs the Python connector surface for SecretSync. Full
+pipeline execution still requires the `secretsync` CLI binary or native
+bindings to be available in the runtime environment.
+</Aside>
+
 ---
 
 ## What You Get
@@ -54,6 +61,10 @@ The `crewai` extra currently resolves to `crewai[tools] >= 1.14.2rc1` because th
 <CardGrid>
   <Card title="Cloud Connectors" icon="seti:cloud">
     Typed clients for AWS, Google Cloud, GitHub, Slack, Vault, Zoom, Anthropic, Cursor, and Meshy.
+  </Card>
+  <Card title="SecretSync Bridge" icon="seti:go">
+    Python-facing access to SecretSync validation, dry-run, and pipeline
+    operations through `vendor_connectors.secrets`.
   </Card>
   <Card title="AI Tool Adapters" icon="seti:graphql">
     Framework-ready tools exposed from the same connector primitives through `get_tools(...)`.
@@ -78,6 +89,15 @@ vc = VendorConnectors()
 github = vc.get_github_client(github_owner="jbcom")
 slack = vc.get_slack_client()
 anthropic = vc.get_anthropic_client()
+```
+
+### SecretSync Connector
+
+```python
+from vendor_connectors.secrets import SecretsConnector
+
+connector = SecretsConnector()
+is_valid, message = connector.validate_config("pipeline.yaml")
 ```
 
 ### Framework Tools
@@ -115,4 +135,5 @@ Meshy is the broadest example because it supports all three surfaces. Other conn
 - [Package source](https://github.com/jbcom/extended-data-library/tree/main/packages/vendor-connectors)
 - [Changelog](https://github.com/jbcom/extended-data-library/blob/main/packages/vendor-connectors/CHANGELOG.md)
 - [API reference](/api/apidocs/vendor_connectors/vendor_connectors/)
+- [SecretSync package](/packages/secretssync/)
 - [Getting started](/getting-started/)

--- a/packages/secretssync/README.md
+++ b/packages/secretssync/README.md
@@ -152,6 +152,10 @@ The recommended way to use SecretSync from Python is via the [vendor-connectors]
 pip install vendor-connectors[secrets]
 ```
 
+This installs the Python connector surface. To execute the full pipeline from
+Python, make sure the `secretsync` CLI is installed or the native bindings have
+been built in the current environment.
+
 ```python
 from vendor_connectors.secrets import SecretsConnector
 

--- a/packages/secretssync/docs/PYTHON_BINDINGS.md
+++ b/packages/secretssync/docs/PYTHON_BINDINGS.md
@@ -1,6 +1,6 @@
 # Python Bindings
 
-SecretSync provides Python bindings via [gopy](https://github.com/go-python/gopy), enabling seamless integration with Python applications, AI agents, and the Extended Data Library ecosystem.
+SecretSync provides Python bindings via [gopy](https://github.com/go-python/gopy), enabling seamless integration with Python applications, AI agents, and the Extended Data Library packages.
 
 ## Overview
 
@@ -15,7 +15,7 @@ The Python bindings expose the core SecretSync functionality:
 
 ### Option 1: Via vendor-connectors (Recommended)
 
-The easiest way to use SecretSync from Python is via the [vendor-connectors](https://github.com/extended-data-library/vendor-connectors) library:
+The easiest way to use SecretSync from Python is via the [vendor-connectors](https://github.com/jbcom/extended-data-library/tree/main/packages/vendor-connectors) library:
 
 ```bash
 pip install vendor-connectors[secrets]
@@ -26,6 +26,9 @@ This provides:
 - CLI fallback when bindings aren't installed
 - AI framework integrations (LangChain, CrewAI, Strands)
 - MCP server support
+
+To execute the full pipeline from Python, keep the `secretsync` CLI installed
+or build the native bindings in the current environment.
 
 ### Option 2: Build Native Bindings
 
@@ -117,7 +120,7 @@ result = connector.run_pipeline("pipeline.yaml")
 # Or customize options
 options = SyncOptions(
     operation=SyncOperation.SYNC,  # Only sync phase
-    targets="production,staging",  # Comma-separated string
+    targets=["production", "staging"],
     parallelism=8,
     continue_on_error=True,
 )

--- a/packages/vendor-connectors/README.md
+++ b/packages/vendor-connectors/README.md
@@ -38,6 +38,7 @@ pip install vendor-connectors
 ```bash
 pip install vendor-connectors[langchain]     # LangChain / LangGraph tool adapters
 pip install vendor-connectors[crewai]        # CrewAI tool adapters
+pip install vendor-connectors[secrets]       # SecretSync Python connector surface
 pip install vendor-connectors[meshy,mcp]     # Meshy MCP server support
 pip install vendor-connectors[webhooks]      # Meshy webhooks
 pip install vendor-connectors[all]           # Everything
@@ -84,6 +85,19 @@ github = GitHubConnector(
     github_token=os.getenv("GITHUB_TOKEN")
 )
 ```
+
+### SecretSync from Python
+
+```python
+from vendor_connectors.secrets import SecretsConnector
+
+connector = SecretsConnector()
+is_valid, message = connector.validate_config("pipeline.yaml")
+```
+
+`vendor-connectors[secrets]` exposes the Python connector surface, but actual
+pipeline execution still requires either the `secretsync` CLI binary or native
+SecretSync bindings to be available in the environment.
 
 ### Three Interfaces Per Connector
 


### PR DESCRIPTION
## Summary
- align SecretSync install commands across the root README, package docs, and docs site
- clarify that `vendor-connectors[secrets]` exposes the Python surface but runtime execution still depends on the `secretsync` CLI or native bindings
- fix the SecretSync Python bindings guide examples and stale monorepo support details

## Validation
- `git diff --check`
- `tox -e docs`
- `bash tools/sphinx-to-astro.sh`
- `cd docs && npm run build`
