### PR TITLE
docs(secretssync): repair package doc links

### DIFF
--- a/packages/secretssync/docs/DEPLOYMENT.md
+++ b/packages/secretssync/docs/DEPLOYMENT.md
@@ -4,7 +4,7 @@ This guide outlines the requirements and different deployment models for the Vau
 
 ## Getting Started
 
-The service can be configured with either a `YAML` or `JSON` configuration file, or via environment variables. The configuration is unmarshalled into the [`ConfigFile`](../internal/config/config.go#L62) struct. An example of a fully configured `YAML` file can be found in [examples/config-full.yaml](../examples/config-full.yaml). To configure via environment variables, you must prefix the environment variable with `SECRETSYNC_` and use `_` to denote nested fields. For example, to set the `queue.type` field, you would set the environment variable `SECRETSYNC_QUEUE_TYPE`. Note: The legacy `VSS_` prefix is still supported for backwards compatibility.
+The service can be configured with either a `YAML` or `JSON` configuration file, or via environment variables. The configuration is unmarshalled into the [`pipeline.Config`](../pkg/pipeline/types.go#L5) struct. An example of a fully configured `YAML` file can be found in [examples/config-full.yaml](../examples/config-full.yaml). To configure via environment variables, you must prefix the environment variable with `SECRETSYNC_` and use `_` to denote nested fields. For example, to set the `queue.type` field, you would set the environment variable `SECRETSYNC_QUEUE_TYPE`. Note: The legacy `VSS_` prefix is still supported for backwards compatibility.
 
 While various examples are provided, the operator intentionally does not ship with a "default" configuration file. This is to ensure that you are aware of the security implications of each component you are enabling. This guide will walk you through each section, what it does, and how to configure it.
 

--- a/packages/secretssync/docs/PUBLISHING_CHECKLIST.md
+++ b/packages/secretssync/docs/PUBLISHING_CHECKLIST.md
@@ -147,23 +147,23 @@ SecretSync is now available as a GitHub Action! This release provides a Docker-b
 
 ### 📚 Documentation
 
-- [GitHub Actions Guide](./docs/GITHUB_ACTIONS.md)
-- [Quick Reference](./docs/ACTION_QUICK_REFERENCE.md)
-- [Example Workflows](./examples/github-action-workflow.yml)
-- [Privacy Policy](./docs/PRIVACY.md)
-- [Support](./docs/SUPPORT.md)
+- [GitHub Actions Guide](./GITHUB_ACTIONS.md)
+- [Quick Reference](./ACTION_QUICK_REFERENCE.md)
+- [Example Workflows](../examples/github-action-workflow.yml)
+- [Privacy Policy](./PRIVACY.md)
+- [Support](./SUPPORT.md)
 
 ### 🔒 Security
 
-SecretSync collects zero data and runs entirely within your GitHub Actions environment. See [Privacy Policy](./docs/PRIVACY.md) for details.
+SecretSync collects zero data and runs entirely within your GitHub Actions environment. See [Privacy Policy](./PRIVACY.md) for details.
 
 ### 🤝 Contributing
 
-We welcome contributions! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
+We welcome contributions! See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
 
 ### 📄 License
 
-MIT License - See [LICENSE](./LICENSE)
+MIT License - See [LICENSE](../LICENSE)
 ```
 
 6. Check "✓ Publish this Action to the GitHub Marketplace"


### PR DESCRIPTION
## Summary
- fix broken relative links in the SecretSync publishing checklist
- point the deployment guide at the real `pipeline.Config` definition instead of a dead path

## Validation
- `git diff --check`
- package-local SecretSync docs link audit
- `cd packages/secretssync && go test ./...`
