### PR TITLE
docs(repo): restore root api reference link

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,11 @@
+# API Reference
+
+This root docs index exists to keep the authored guides in `docs/guides/` and
+`docs/getting-started/` linked to the current API reference entry point.
+
+The maintained API overview for the docs site lives in:
+
+- [Astro API overview](../src/content/docs/api/index.md)
+- [Generated package index](../src/content/docs/api/apidocs/index.md)
+
+The published docs site exposes that content at `/api/`.

--- a/docs/guides/api-surface.md
+++ b/docs/guides/api-surface.md
@@ -131,4 +131,4 @@ constructors, representers, or preserving YAML-native wrappers during export.
 - [Quickstart](../getting-started/quickstart.md)
 - [Serialization Guide](./serialization.md)
 - [Transformations Guide](./transformations.md)
-- [API Reference](../api/index.rst)
+- [API Reference](../api/index.md)


### PR DESCRIPTION
## Summary
- add a stable root docs API index alias for authored guides
- update the API surface guide to point at the maintained markdown index instead of a removed rst path
- keep repo-local docs cross-links valid without pointing guides at generated docs internals

## Validation
- git diff --check
- repo markdown link audit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new root-level API reference index page serving as a central entry point for accessing API documentation, maintained overview, and generated package index resources.
  * Updated internal documentation links to correctly reference the new API documentation structure, ensuring seamless navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->