### PR TITLE
docs(repo): align published docs domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📚 Documentation
-    url: https://extendeddata.dev
+    url: https://extended-data.dev
     about: Read the package guides, examples, and API docs before filing an issue
   - name: 🛡️ Security Policy
     url: https://github.com/jbcom/extended-data-library/security/policy

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ feat!: breaking API change             # major bump
 
 ## Documentation
 
-Full documentation is available at [extendeddata.dev](https://extendeddata.dev).
+Full documentation is available at [extended-data.dev](https://extended-data.dev).
 
 ## License
 

--- a/packages/directed-inputs-class/README.md
+++ b/packages/directed-inputs-class/README.md
@@ -313,5 +313,5 @@ Contributions are welcome! Please see the [Contributing Guidelines](https://gith
 
 - [**PyPI**](https://pypi.org/project/directed-inputs-class/)
 - [**GitHub**](https://github.com/jbcom/extended-data-library/tree/main/packages/directed-inputs-class)
-- [**Documentation**](https://extendeddata.dev/packages/inputs/)
+- [**Documentation**](https://extended-data.dev/packages/inputs/)
 - [**Changelog**](https://github.com/jbcom/extended-data-library/blob/main/packages/directed-inputs-class/CHANGELOG.md)

--- a/packages/directed-inputs-class/pyproject.toml
+++ b/packages/directed-inputs-class/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://extendeddata.dev/packages/inputs/"
+Documentation = "https://extended-data.dev/packages/inputs/"
 Issues = "https://github.com/jbcom/extended-data-library/issues"
 Source = "https://github.com/jbcom/extended-data-library/tree/main/packages/directed-inputs-class"
 Changelog = "https://github.com/jbcom/extended-data-library/blob/main/packages/directed-inputs-class/CHANGELOG.md"

--- a/packages/extended-data-types/README.md
+++ b/packages/extended-data-types/README.md
@@ -49,8 +49,8 @@ print(hcl_text)
 
 ## Documentation
 
-- Package docs: [extendeddata.dev/core/data-types](https://extendeddata.dev/core/data-types/)
-- Monorepo docs: [extendeddata.dev](https://extendeddata.dev)
+- Package docs: [extended-data.dev/core/data-types](https://extended-data.dev/core/data-types/)
+- Monorepo docs: [extended-data.dev](https://extended-data.dev)
 - Examples: [packages/extended-data-types/examples](https://github.com/jbcom/extended-data-library/tree/main/packages/extended-data-types/examples)
 
 ## Contributing
@@ -62,5 +62,5 @@ Contributions are welcome. See the shared
 
 - [PyPI](https://pypi.org/project/extended-data-types/)
 - [GitHub](https://github.com/jbcom/extended-data-library/tree/main/packages/extended-data-types)
-- [Documentation](https://extendeddata.dev/core/data-types/)
+- [Documentation](https://extended-data.dev/core/data-types/)
 - [Changelog](https://github.com/jbcom/extended-data-library/blob/main/packages/extended-data-types/CHANGELOG.md)

--- a/packages/extended-data-types/examples/README.md
+++ b/packages/extended-data-types/examples/README.md
@@ -16,9 +16,9 @@ guides and are part of the documented contract, not throwaway snippets.
 
 ## Related Documentation
 
-- [Package docs](https://extendeddata.dev/core/data-types/)
-- [Getting started](https://extendeddata.dev/getting-started/)
-- [Packages overview](https://extendeddata.dev/packages/)
+- [Package docs](https://extended-data.dev/core/data-types/)
+- [Getting started](https://extended-data.dev/getting-started/)
+- [Packages overview](https://extended-data.dev/packages/)
 
 ## Running Examples
 

--- a/packages/extended-data-types/pyproject.toml
+++ b/packages/extended-data-types/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://extendeddata.dev/core/data-types/"
+Documentation = "https://extended-data.dev/core/data-types/"
 Issues = "https://github.com/jbcom/extended-data-library/issues"
 Source = "https://github.com/jbcom/extended-data-library/tree/main/packages/extended-data-types"
 Changelog = "https://github.com/jbcom/extended-data-library/blob/main/packages/extended-data-types/CHANGELOG.md"

--- a/packages/lifecyclelogging/README.md
+++ b/packages/lifecyclelogging/README.md
@@ -114,5 +114,5 @@ Contributions are welcome! Please see the [Contributing Guidelines](https://gith
 
 - [**PyPI**](https://pypi.org/project/lifecyclelogging/)
 - [**GitHub**](https://github.com/jbcom/extended-data-library/tree/main/packages/lifecyclelogging)
-- [**Documentation**](https://extendeddata.dev/packages/logging/)
+- [**Documentation**](https://extended-data.dev/packages/logging/)
 - [**Changelog**](https://github.com/jbcom/extended-data-library/blob/main/packages/lifecyclelogging/CHANGELOG.md)

--- a/packages/lifecyclelogging/pyproject.toml
+++ b/packages/lifecyclelogging/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://extendeddata.dev/packages/logging/"
+Documentation = "https://extended-data.dev/packages/logging/"
 Issues = "https://github.com/jbcom/extended-data-library/issues"
 Source = "https://github.com/jbcom/extended-data-library/tree/main/packages/lifecyclelogging"
 Changelog = "https://github.com/jbcom/extended-data-library/blob/main/packages/lifecyclelogging/CHANGELOG.md"

--- a/packages/secretssync/Makefile
+++ b/packages/secretssync/Makefile
@@ -41,7 +41,7 @@ python-bindings:
 	$(GOPY) pkg -output=$(PYTHON_OUTPUT) -vm=$(PYTHON) -name=$(PYTHON_PKG) \
 		-version=$(VERSION) \
 		-author="Extended Data Library" \
-		-email="support@extendeddata.dev" \
+		-email="support@extended-data.dev" \
 		-url="https://github.com/jbcom/extended-data-library/packages/secretssync" \
 		-desc="Enterprise-grade secret synchronization pipeline with Python bindings" \
 		./python/secretssync

--- a/packages/vendor-connectors/README.md
+++ b/packages/vendor-connectors/README.md
@@ -138,5 +138,5 @@ Contributions are welcome! Please see the [Contributing Guidelines](https://gith
 
 - [**PyPI**](https://pypi.org/project/vendor-connectors/)
 - [**GitHub**](https://github.com/jbcom/extended-data-library/tree/main/packages/vendor-connectors)
-- [**Documentation**](https://extendeddata.dev/packages/vendor-connectors/)
+- [**Documentation**](https://extended-data.dev/packages/vendor-connectors/)
 - [**Changelog**](https://github.com/jbcom/extended-data-library/blob/main/packages/vendor-connectors/CHANGELOG.md)

--- a/packages/vendor-connectors/pyproject.toml
+++ b/packages/vendor-connectors/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://extendeddata.dev/packages/vendor-connectors/"
+Documentation = "https://extended-data.dev/packages/vendor-connectors/"
 Issues = "https://github.com/jbcom/extended-data-library/issues"
 Source = "https://github.com/jbcom/extended-data-library/tree/main/packages/vendor-connectors"
 Changelog = "https://github.com/jbcom/extended-data-library/blob/main/packages/vendor-connectors/CHANGELOG.md"


### PR DESCRIPTION
## Summary
- switch public documentation links from extendeddata.dev to the live extended-data.dev domain
- align package metadata, README links, example docs links, and the issue-template docs contact URL
- update the SecretSync Python binding contact email to the resolving docs domain

## Validation
- git diff --check
- grep sweep for stale extendeddata.dev docs URLs
- uv build --package extended-data-types
- uv build --package directed-inputs-class
- uv build --package lifecyclelogging
- uv build --package vendor-connectors
