### PR TITLE
fix(secretssync): remove published module replace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,14 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: packages/secretssync/go.sum
 
+      - name: Assert installable Go module metadata
+        working-directory: packages/secretssync
+        run: |
+          if grep -q '^replace ' go.mod; then
+            echo "packages/secretssync/go.mod must not contain replace directives for a published installable module"
+            exit 1
+          fi
+
       - name: Run Go tests
         working-directory: packages/secretssync
         run: go test -v -race ./...

--- a/packages/secretssync/go.mod
+++ b/packages/secretssync/go.mod
@@ -2,9 +2,6 @@ module github.com/jbcom/extended-data-library/packages/secretssync
 
 go 1.25.3
 
-// required for hashicorp/vault
-replace github.com/pires/go-proxyproto v1.0.0 => github.com/pires/go-proxyproto v0.7.0
-
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14


### PR DESCRIPTION
## Summary
- remove the stale `replace` directive from `packages/secretssync/go.mod`
- restore installability for the published SecretSync Go module on the next release
- add a CI guard so published installable Go modules cannot regress back to `replace` directives

## Why
The documented install path currently fails against the released SecretSync tag:

```bash
GOWORK=off go install github.com/jbcom/extended-data-library/packages/secretssync/cmd/secretsync@secretssync-v2.0.1
```

Go rejects released modules that contain `replace` directives, and the existing replacement is no longer needed by the current Vault API dependency tree.

## Validation
- `cd packages/secretssync && go test ./...`
- `cd packages/secretssync && go mod tidy`
- `cd packages/secretssync && if grep -q '^replace ' go.mod; then exit 1; fi`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "OK"'`
