### PR TITLE
docs(secretssync): refresh action tag examples

### DIFF
--- a/docs/src/content/docs/packages/secretssync.mdx
+++ b/docs/src/content/docs/packages/secretssync.mdx
@@ -121,7 +121,7 @@ targets:
 
 ```yaml
 - name: Sync Secrets
-  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
     dry-run: "false"

--- a/packages/secretssync/README.md
+++ b/packages/secretssync/README.md
@@ -288,7 +288,7 @@ SecretSync is available as a GitHub Action for seamless CI/CD integration:
 
 ```yaml
 - name: Sync Secrets
-  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
     dry-run: 'false'

--- a/packages/secretssync/docs/ACTION_QUICK_REFERENCE.md
+++ b/packages/secretssync/docs/ACTION_QUICK_REFERENCE.md
@@ -3,14 +3,14 @@
 ## Installation
 
 ```yaml
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
 ```
 
 ## Minimal Example
 
 ```yaml
 - name: Sync Secrets
-  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
   env:
@@ -39,7 +39,7 @@
 ### Dry Run (PR Validation)
 
 ```yaml
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
     dry-run: 'true'
@@ -49,7 +49,7 @@
 ### Specific Targets
 
 ```yaml
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
     targets: 'Staging,Production'
@@ -58,7 +58,7 @@
 ### Merge Only
 
 ```yaml
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
     merge-only: 'true'
@@ -67,7 +67,7 @@
 ### With Exit Codes
 
 ```yaml
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
     dry-run: 'true'
@@ -78,7 +78,7 @@
 ### Debug Mode
 
 ```yaml
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
     log-level: 'debug'
@@ -112,7 +112,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
         env:
@@ -216,7 +216,7 @@ Use with `continue-on-error: true` to handle:
 ```yaml
 - name: Check Changes
   id: check
-  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     dry-run: 'true'
     exit-code: 'true'
@@ -233,7 +233,7 @@ Use with `continue-on-error: true` to handle:
 
 ```yaml
 - uses: actions/checkout@v4  # Must checkout first!
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: path/to/config.yaml  # Relative to repo root
 ```
@@ -258,7 +258,7 @@ Ensure OIDC is configured correctly and trust policy allows your repository.
 
 ```yaml
 # Recommended: Pin to a package release tag
-uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
 
 # Not recommended: Track the branch tip
 uses: jbcom/extended-data-library/packages/secretssync@main

--- a/packages/secretssync/docs/FAQ.md
+++ b/packages/secretssync/docs/FAQ.md
@@ -231,7 +231,7 @@ Use the GitHub Action:
 
 ```yaml
 - name: Sync Secrets
-  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
     dry-run: 'false'

--- a/packages/secretssync/docs/GETTING_STARTED.md
+++ b/packages/secretssync/docs/GETTING_STARTED.md
@@ -224,7 +224,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
         env:

--- a/packages/secretssync/docs/GITHUB_ACTIONS.md
+++ b/packages/secretssync/docs/GITHUB_ACTIONS.md
@@ -30,7 +30,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
 ```
@@ -86,7 +86,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Validate Changes (Dry Run)
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
           dry-run: 'true'
@@ -133,7 +133,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
           targets: ${{ github.event.inputs.targets != 'all' && github.event.inputs.targets || '' }}
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Merge Secrets
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
           merge-only: 'true'
@@ -200,7 +200,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync with Discovery
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
           discover: 'true'
@@ -241,7 +241,7 @@ jobs:
       
       - name: Check for Changes
         id: check
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
           dry-run: 'true'
@@ -254,7 +254,7 @@ jobs:
       
       - name: Apply Changes
         if: steps.check.outcome == 'failure'
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
           output-format: 'github'
@@ -300,7 +300,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: configs/${{ github.event.inputs.environment }}.yaml
           output-format: 'github'
@@ -392,7 +392,7 @@ jobs:
   sync-production:
     environment: production  # Requires approval
     steps:
-      - uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+      - uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: production.yaml
 ```
@@ -514,7 +514,7 @@ Ensure your config file is in the repository and the path is correct:
 ```yaml
 - uses: actions/checkout@v4  # Required to access repository files
 
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: path/to/config.yaml  # Relative to repo root
 ```
@@ -524,7 +524,7 @@ Ensure your config file is in the repository and the path is correct:
 Verify environment variables are set correctly:
 
 ```yaml
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
     log-level: debug  # Enable debug logging
@@ -546,7 +546,7 @@ Check:
 Ensure `output-format` is set to `github`:
 
 ```yaml
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     output-format: 'github'  # Enables GitHub Actions annotations
 ```
@@ -566,7 +566,7 @@ Example using exit codes:
 ```yaml
 - name: Check for Changes
   id: check
-  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     dry-run: 'true'
     exit-code: 'true'
@@ -608,7 +608,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Sync Secrets
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: configs/${{ matrix.environment }}.yaml
 ```
@@ -628,7 +628,7 @@ jobs:
   sync:
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+      - uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
 ```
 
 ### Composite Actions
@@ -651,7 +651,7 @@ runs:
         role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
         aws-region: us-east-1
     
-    - uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+    - uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
       with:
         config: ${{ inputs.config }}
         output-format: 'github'

--- a/packages/secretssync/docs/PIPELINE.md
+++ b/packages/secretssync/docs/PIPELINE.md
@@ -360,7 +360,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Run Pipeline
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
           targets: ${{ inputs.targets || '' }}

--- a/packages/secretssync/docs/PUBLISHING_CHECKLIST.md
+++ b/packages/secretssync/docs/PUBLISHING_CHECKLIST.md
@@ -137,7 +137,7 @@ SecretSync is now available as a GitHub Action! This release provides a Docker-b
 
 ```yaml
 - name: Sync Secrets
-  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+  uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
   env:

--- a/packages/secretssync/docs/SUPPORT.md
+++ b/packages/secretssync/docs/SUPPORT.md
@@ -93,7 +93,7 @@ When reporting bugs, please include:
    
    # If using GitHub Action
    # Include the version/tag from your workflow
-   uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+   uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
    ```
 
 2. **Configuration** (sanitized - remove secrets!)
@@ -232,10 +232,10 @@ Yes! SecretSync is production-ready. Many organizations use it daily.
 For GitHub Actions:
 ```yaml
 # Pin to major version (recommended)
-uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
 
 # Pin to specific version (most stable)
-uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
 
 # Use latest (not recommended for production)
 uses: jbcom/extended-data-library/packages/secretssync@main

--- a/packages/secretssync/docs/getting-started/installation.md
+++ b/packages/secretssync/docs/getting-started/installation.md
@@ -37,7 +37,7 @@ make build
 Use the packaged action from the monorepo subdirectory and pin to a package tag:
 
 ```yaml
-- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+- uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
   with:
     config: config.yaml
 ```

--- a/packages/secretssync/examples/github-action-workflow.yml
+++ b/packages/secretssync/examples/github-action-workflow.yml
@@ -67,7 +67,7 @@ jobs:
           aws-region: us-east-1
       
       - name: Validate Configuration (Dry Run)
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: config.yaml
           dry-run: 'true'
@@ -107,7 +107,7 @@ jobs:
           role-session-name: GitHubActions-SecretSync-${{ github.run_id }}
       
       - name: Run SecretSync
-        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.1
+        uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
         with:
           config: ${{ steps.config.outputs.config }}
           targets: ${{ github.event.inputs.targets || '' }}


### PR DESCRIPTION
## Summary
- update active SecretSync docs and examples from `secretssync-v2.0.1` to the live `secretssync-v2.0.2` action tag
- keep the package README, published docs page, repo docs, and example workflow aligned with the current release

## Validation
- `git diff --check`
- `rg -n "secretssync-v2\.0\.1" README.md docs packages .github AGENTS.md tools -g '!**/CHANGELOG.md' -g '!docs/dist/**' -g '!docs/node_modules/**'`
- `ruby -e 'require "yaml"; YAML.load_file("packages/secretssync/examples/github-action-workflow.yml"); puts "OK"'`
