### PR TITLE
docs(secretssync): fix action version guidance

### DIFF
--- a/packages/secretssync/docs/MARKETPLACE.md
+++ b/packages/secretssync/docs/MARKETPLACE.md
@@ -337,8 +337,8 @@ This action is MIT licensed and free. Paid versions require different licensing.
 ### How do version tags work?
 
 Users can reference:
-- `@v1` - Latest v1.x.x (auto-updates)
-- `@v1.2.3` - Specific version (pinned)
+- `@secretssync-v2.0.2` - Current package release tag (recommended)
+- `@secretssync-vX.Y.Z` - Exact package release tag (pinned)
 - `@main` - Latest commit (not recommended)
 
 ### What if my action has dependencies?

--- a/packages/secretssync/docs/SUPPORT.md
+++ b/packages/secretssync/docs/SUPPORT.md
@@ -231,13 +231,13 @@ Yes! SecretSync is production-ready. Many organizations use it daily.
 
 For GitHub Actions:
 ```yaml
-# Pin to major version (recommended)
+# Pin to the current package release tag (recommended)
 uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
 
-# Pin to specific version (most stable)
+# Pin to an exact package release tag (most stable)
 uses: jbcom/extended-data-library/packages/secretssync@secretssync-v2.0.2
 
-# Use latest (not recommended for production)
+# Track the branch tip (not recommended for production)
 uses: jbcom/extended-data-library/packages/secretssync@main
 ```
 


### PR DESCRIPTION
## Summary
- fix SecretSync action version guidance in the support and marketplace docs
- replace the misleading floating-major examples with the package-scoped release tag format this repo actually publishes
- keep the docs consistent with the current `secretssync-v2.0.2` release model

## Validation
- `git diff --check`
- `sed -n '232,246p' packages/secretssync/docs/SUPPORT.md`
- `sed -n '336,344p' packages/secretssync/docs/MARKETPLACE.md`
