### PR TITLE
[codex] align gh cli guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,8 @@ cd packages/secretssync && go test ./...
 
 ## GitHub CLI
 
-Use `gh` directly with the existing local authentication context.
+Use `gh` directly with the existing local authentication context. Do not wrap
+local commands with `GH_TOKEN=...`.
 
 ```bash
 gh auth status

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ tox -e py310-edt,py311-edt,py312-edt,py313-edt,py314-edt
 
 ## GitHub CLI
 
-Use `gh` directly with the existing local authentication context.
+Use `gh` directly with the existing local authentication context. Do not prefix
+local commands with `GH_TOKEN=...`.
 
 ```bash
 gh auth status


### PR DESCRIPTION
## Summary
- align the repo-level `gh` usage guidance in `AGENTS.md`
- align the Copilot instruction surface with the same `gh` guidance
- keep the leftover Codex delta isolated to the only two real unmerged instruction edits

## Why
A stale local umbrella branch still existed in the original checkout, but auditing it showed the branch itself should not be revived as a PR. The only legitimate remaining deltas were these two instruction clarifications: use the existing authenticated `gh` context directly and do not prefix local commands with `GH_TOKEN=...`.

## Impact
This keeps the live agent and Copilot guidance aligned with the current repo workflow and avoids reintroducing obsolete branch history or old agent scaffolding.

## Validation
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub CLI authentication guidance for internal development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->